### PR TITLE
[86] Add `Canvas` text and code support

### DIFF
--- a/src/js/app/mainColors.js
+++ b/src/js/app/mainColors.js
@@ -28,7 +28,7 @@ const renderColorsTab = `
         </div>
       </div>
       <footer class="flex justify-center mt-10">
-		${renderButton({ id: 'resetAllAccents', content: 'Reset Fonts', disabled: false, className: 'btn-primary' })}
+		${renderButton({ id: 'resetAllAccents', content: 'Reset Colors', disabled: false, className: 'btn-primary' })}
       </footer>
     </section>
 `

--- a/src/sass/abstract/_bp.scss
+++ b/src/sass/abstract/_bp.scss
@@ -72,3 +72,48 @@ $xxl: 96em; // 1536px
 @include dev('xxl') {
     // Your styles for 2x extra-large screens (min-width: 1536px)
 } */
+
+
+@mixin container($bp) {
+    @if $bp =='xxs' {
+        @container (max-width: #{$xxs}) {
+            @content;
+        }
+    }
+
+    @if $bp =='xs' {
+        @container (max-width: #{$xs}) {
+            @content;
+        }
+    }
+
+    @if $bp =='sm' {
+        @container (max-width: #{$sm}) {
+            @content;
+        }
+    }
+
+    @if $bp =='md' {
+        @container (max-width: #{$md}) {
+            @content;
+        }
+    }
+
+    @if $bp =='lg' {
+        @container (max-width: #{$lg}) {
+            @content;
+        }
+    }
+
+    @if $bp =='xl' {
+        @container (max-width: #{$xl}) {
+            @content;
+        }
+    }
+
+    @if $bp =='xxl' {
+        @container (min-width: #{$xxl}) {
+            @content;
+        }
+    }
+}

--- a/src/sass/abstract/_bp.scss
+++ b/src/sass/abstract/_bp.scss
@@ -74,7 +74,7 @@ $xxl: 96em; // 1536px
 } */
 
 
-@mixin container($bp) {
+/* @mixin container($bp) {
     @if $bp =='xxs' {
         @container (max-width: #{$xxs}) {
             @content;
@@ -113,6 +113,50 @@ $xxl: 96em; // 1536px
 
     @if $bp =='xxl' {
         @container (min-width: #{$xxl}) {
+            @content;
+        }
+    }
+} */
+
+@mixin container($bp, $name: main) {
+    @if $bp =='xxs' {
+        @container #{$name} (max-width: #{$xxs}) {
+            @content;
+        }
+    }
+
+    @if $bp =='xs' {
+        @container #{$name} (max-width: #{$xs}) {
+            @content;
+        }
+    }
+
+    @if $bp =='sm' {
+        @container #{$name} (max-width: #{$sm}) {
+            @content;
+        }
+    }
+
+    @if $bp =='md' {
+        @container #{$name} (max-width: #{$md}) {
+            @content;
+        }
+    }
+
+    @if $bp =='lg' {
+        @container #{$name} (max-width: #{$lg}) {
+            @content;
+        }
+    }
+
+    @if $bp =='xl' {
+        @container #{$name} (max-width: #{$xl}) {
+            @content;
+        }
+    }
+
+    @if $bp =='xxl' {
+        @container #{$name} (min-width: #{$xxl}) {
             @content;
         }
     }

--- a/src/sass/abstract/_vars.scss
+++ b/src/sass/abstract/_vars.scss
@@ -37,7 +37,7 @@
 
 	/* ? --- Paddings --- */
 	--p-chat-bubble: 1.2rem;
-	--px-chat-bubble-edge-gap: 4vw;
+	// --px-chat-bubble-edge-gap: 4vw;
 	--p-contextmenu: 0.8rem;
 	--p-contextmenu-item: 0.9rem 1rem;
 	--p-prompt-textarea: 0.7rem;
@@ -133,6 +133,16 @@
 
 	--link: var(--c-accent) !important;
 
+	@include container('md') {
+		// --px-chat-bubble-edge-gap: 1vw;
+		--p-chat-bubble: .8rem;
+		--br-chat-bubble: calc(var(--br) * 1.1);
+	}
+
+	@include container('sm') {
+		--br-chat-bubble: var(--br) !important;
+	}
+
 	@include dev('md') {
 		--p-chat-bubble: .8rem;
 		--br-chat-bubble: calc(var(--br) * 1.55);
@@ -143,9 +153,9 @@
 		--p-sidebar-nav: 0.3rem;
 	}
 
-	@include dev('sm') {
-		--px-chat-bubble-edge-gap: 0.45rem;
-	}
+	// @include dev('sm') {
+	// 	--px-chat-bubble-edge-gap: 0.45rem;
+	// }
 
 
 	// --box-shadow-sticky: 0 10px 40px 5px hsla(var(--accent-h) var(--surface-s) calc(var(--surface-l) * 1.025) / 0.85);

--- a/src/sass/abstract/_vars.scss
+++ b/src/sass/abstract/_vars.scss
@@ -245,6 +245,10 @@ html.light {
 	--c-bg-pre-header-btn-color: var(--c-txt);
 	--c-markdown-a: var(--c-accent);
 
+	/* ========== CodeMirror Editor ========== */
+	--c-bg-cm: var(--c-surface-1);
+
+
 	/* ? ========== Scrollbar colors ========== */
 	--c-scrollbar-thumb: var(--c-surface-3);
 	--c-scrollbar-track: transparent;
@@ -380,6 +384,10 @@ html.dark {
 	--c-bg-pre-header-btn: var(--c-accent);
 	--c-bg-pre-header-btn-color: var(--c-on-accent);
 	--c-markdown-a: var(--c-accent);
+
+	/* ========== CodeMirror Editor ========== */
+	// --c-bg-cm: var(--c-bg-pre); // surface-1
+	--c-bg-cm: var(--c-surface-1); // surface-1
 
 	/* ? ========== Scrollbar colors ========== */
 	--c-scrollbar-thumb: var(--c-surface-3);

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -65,5 +65,23 @@
                 background-color: var(--c-bg-cm);
             }
         }
+
+
+        /*  Canvas Edit floating button on bottom right */
+        main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
+
+            /* Wrapper */
+            &.bg-token-main-surface-primary {
+                background-color: hsla(var(--accent-hsl) / .2) !important;
+                color: var(--c-accent) !important;
+                backdrop-filter: blur(10px);
+
+                .bg-gray-300 {
+                    background-color: var(--c-accent) !important;
+                }
+            }
+
+
+        }
     }
 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -175,8 +175,8 @@
             /* Blue Highlight when hover text to add a comment in Text Canvas */
             [class*="dark:after:bg-[Highlight]"] {
                 &::after {
-                    background-color: hsla(var(--accent-hsl) / .12) !important;
-                    border: 1px solid hsla(var(--accent-hsl) / .12) !important;
+                    background-color: hsla(var(--accent-hsl) / .15) !important;
+                    border: 1px solid hsla(var(--accent-hsl) / .15) !important;
                 }
             }
 
@@ -184,6 +184,15 @@
             .selection-highlight.bg-\[Highlight\] {
                 background-color: var(--c-accent) !important;
                 color: var(--c-on-accent) !important;
+            }
+
+            /* Comment section on the right of the text where add comment btn is */
+            [data-block-comment-launcher] button {
+                .text-gray-400 {
+                    svg {
+                        color: var(--c-accent) !important;
+                    }
+                }
             }
         }
     }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -97,16 +97,9 @@
         section.popover.h-full.w-full {
             background-color: var(--c-bg-cm) !important;
 
-            /* Canvas wrapper, this is also bg color for the console */
-            /* &,
-            .bg-token-main-surface-primary {
-                --main-surface-primary: var(--c-bg-cm) !important;
-                // background-color: var(--c-bg-cm) !important;
-            } */
-
             /* Resizing line */
             .cursor-ns-resize.bg-token-text-quaternary {
-                background-color: hsla(var(--accent-hsl) / .4) !important;
+                background-color: hsla(var(--accent-hsl) / .5) !important;
             }
 
             /* Header of canvas with title, coppy btn */
@@ -116,8 +109,38 @@
 
             /* Borders in console */
             .border-token-border-xlight {
-                --border-xlight: hsla(var(--accent-hsl) / .05) !important;
+                --border-xlight: hsla(var(--accent-hsl) / .1) !important;
                 // border-color: var(--border-xlight);
+            }
+
+            /* Code Canvas: Console when "Run" Python code */
+            & > .relative:has(>.cursor-ns-resize) {
+
+                /* Console bg */
+                .bg-token-main-surface-primary {
+                    --main-surface-primary: var(--c-bg-cm) !important;
+                }
+
+                .sticky.top-0.z-10.font-mono.text-sm[class*="dark:hover:bg-gray-700"] {
+                    &:hover {
+                        background-color: var(--c-surface-2) !important;
+                    }
+                }
+
+                /* "Clear console" and "Cancel" btns in Console header */
+                button[as="button"].btn.btn-ghost.btn-small.aspect-square.\!p-1:has(svg) {
+                    color: var(--c-accent) !important;
+                }
+
+                /* Error output in consoles: this is applied from my global bg-red style so we have to reset it */
+                .font-mono[class*="hover:bg-red-500"] {
+                    background-color: transparent !important;
+                    border: none !important;
+
+                    &:hover {
+                        background-color: hsla(var(--danger-hsl) / .11) !important;
+                    }
+                }
             }
         }
 
@@ -269,42 +292,6 @@
                     &.\:bg-white\/50 {
                         background-color: var(--c-bg-cm) !important;
                     }
-                }
-            }
-        }
-
-
-        /* Code Canvas: Console when "Run" Python code */
-        section > .relative:has(>.cursor-ns-resize) {
-
-            // Console bg
-            .bg-token-main-surface-primary {
-                --main-surface-primary: var(--c-bg-cm) !important;
-                // background-color: var(--c-bg-cm) !important;
-            }
-
-            /* Da obrisemo border za "Console" header jer je bila neka ruzna bela samo za njega */
-            // .border-token-border-xlight:not(.font-mono) {
-            //     border: none !important;
-            // }
-
-            .sticky.top-0.z-10.font-mono.text-sm[class*="dark:hover:bg-gray-700"] {
-                &:hover {
-                    background-color: var(--c-surface-2) !important;
-                }
-            }
-
-            button[as="button"].btn.btn-ghost.btn-small.aspect-square.\!p-1:has(svg) {
-                color: var(--c-accent) !important;
-            }
-
-            /* Error output in consoles */
-            .font-mono[class*="hover:bg-red-500/10"] {
-                background-color: transparent !important;
-                border: none !important;
-
-                &:hover {
-                    background-color: hsla(var(--danger-hsl) / .11) !important;
                 }
             }
         }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -126,33 +126,58 @@
             }
         }
 
-        /* ___________ "Ask a ChatGPT" and "Edit or expain..." floating wrapper */
-        main .absolute.z-50 {
+        main {
 
-            /* "Ask a ChatGPT" and toolbar wrapper */
-            &:has(> .h-10[role="toolbar"]) {
-                .h-10[role="toolbar"] {
+            /* ___________ "Ask a ChatGPT" and "Edit or expain..." floating wrapper */
+            .absolute.z-50 {
 
-                    &.bg-token-main-surface-primary {
-                        --main-surface-primary: var(--c-surface-2) !important;
-                        border: 1px solid hsla(var(--accent-hsl) / .14) !important;
+                /* "Ask a ChatGPT" and toolbar wrapper */
+                &:has(> .h-10[role="toolbar"]) {
+                    .h-10[role="toolbar"] {
 
-                        /* "Ask a ChatGPT" and toolbar buttons hover states */
-                        button[class*="hover:bg-[#f5f5f5]"]:hover {
-                            background-color: var(--c-surface-3) !important;
+                        &.bg-token-main-surface-primary {
+                            --main-surface-primary: var(--c-surface-2) !important;
+                            border: 1px solid hsla(var(--accent-hsl) / .14) !important;
+
+                            /* "Ask a ChatGPT" and toolbar buttons hover states */
+                            button[class*="hover:bg-[#f5f5f5]"]:hover {
+                                background-color: var(--c-surface-3) !important;
+                            }
                         }
                     }
                 }
+
+                /* "Edit or explain" wrapper */
+                .relative.bg-token-main-surface-primary:has(>textarea[aria-placeholder^="Edit or explain"]) {
+                    background-color: hsla(var(--accent-hsl) / .1) !important;
+
+                    /* "Edit or explain" field overlay */
+                    .backdrop-saturate-25 {
+                        background-color: hsla(var(--accent-hsl) / .1) !important;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* Width less then 1000px */
+.fixed.inset-0.z-40.overflow-hidden {
+
+    /* "Ask a ChatGPT to edit" on full-width screen less then 1000px width */
+    [class*="bg-[#f4f4f4]"]:has([placeholder="Ask ChatGPT to edit"]) {
+        background-color: var(--c-bg-textarea) !important;
+
+        /* Submit btn */
+        button.rounded-full.bg-token-main-surface-primary {
+            background-color: var(--c-accent) !important;
+
+            svg {
+                color: var(--c-on-accent) !important;
             }
 
-            /* "Edit or explain" wrapper */
-            .relative.bg-token-main-surface-primary:has(>textarea[aria-placeholder^="Edit or explain"]) {
-                background-color: hsla(var(--accent-hsl) / .1) !important;
-
-                /* "Edit or explain" field overlay */
-                .backdrop-saturate-25 {
-                    background-color: hsla(var(--accent-hsl) / .1) !important;
-                }
+            &:disabled {
+                background-color: hsla(var(--accent-hsl) / .12) !important;
             }
         }
     }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -49,6 +49,11 @@
 
     &:has(section.popover main #codemirror, section.popover main #prosemirror-editor-container) {
 
+        .bg-black {
+            background-color: var(--c-accent) !important;
+            color: var(--c-on-accent) !important;
+        }
+
         /* 
         - Edit Canvas floating action button warapper on the bottom right
         - "Ask GPT" floating wrapper */
@@ -67,7 +72,7 @@
         }
 
 
-        /*  Canvas Edit floating button on bottom right */
+        /* @@@@@@@@@ Canvas Edit floating button on bottom right */
         // main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
         .absolute.z-\[70\].overflow-visible.border.border-token-border-light.transition-colors {
 
@@ -130,10 +135,50 @@
                 }
             }
         }
+
+
+        /* ___________ "Ask a ChatGPT" and "Edit or expain..." floating wrapper */
+        main .absolute.z-50 {
+
+            /* "Ask a ChatGPT" and toolbar wrapper */
+            &:has(> .h-10[role="toolbar"]) {
+                .h-10[role="toolbar"] {
+
+                    &.bg-token-main-surface-primary {
+                        --main-surface-primary: var(--c-surface-2) !important;
+                        border: 1px solid hsla(var(--accent-hsl) / .14) !important;
+                        // background-color: hsla(var(--accent-hsl) / .2) !important;
+                        // background-color: var(--c-accent-light)!important;
+
+                        /* "Ask a ChatGPT" and toolbar buttons hover states */
+                        button[class*="hover:bg-[#f5f5f5]"]:hover {
+                            background-color: var(--c-surface-3) !important;
+                            // background-color: var(--c-accent) !important;
+                            // color: var(--c-on-accent) !important;
+                        }
+
+                        /* Toolbar buttons like: "Bold", "Italic", "Text style" */
+                        // button.bg-token-main-surface-secondary:has(svg) {
+                        //     // color: var(--c-accent) !important;
+                        // }
+                    }
+                }
+            }
+
+            /* "Edit or explain" wrapper */
+            .relative.bg-token-main-surface-primary:has(>textarea[aria-placeholder^="Edit or explain"]) {
+                background-color: hsla(var(--accent-hsl) / .1) !important;
+
+                /* "Edit or explain" field overlay */
+                .backdrop-saturate-25 {
+                    background-color: hsla(var(--accent-hsl) / .1) !important;
+                }
+            }
+        }
     }
 }
 
-
-
-/* hover\:bg-gray-100\/75 .dark\:hover\:bg-gray-700 .bg-gray-100\/50 .dark\:bg-gray-700\/50 */
-// hover:bg-gray-100/75 .dark:hover:bg-gray-700
+/* 
+"Port to a language" classes:
+.hover\:bg-gray-100\/75 .dark\:hover\:bg-gray-700 .bg-gray-100\/50 .dark\:bg-gray-700\/50
+.hover:bg-gray-100/75 .dark:hover:bg-gray-700 */

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -292,6 +292,8 @@
 
             /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
             .selection-highlight.bg-\[Highlight\],
+            // Text Canvas: blue highlight when text started to proccesing "Apply" from GPT comment
+            .selection-highlight.\!bg-\[Highlight\],
             // Code Canvas: blue highlight of current line when code rewwriting
             .cm-editor .cm-line.\!bg-\[Highlight\],
 

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -48,18 +48,10 @@
 .fixed.inset-0.z-40.overflow-hidden {
 
     &:has(section.popover main #codemirror, section.popover main #prosemirror-editor-container) {
-
         .bg-black {
             background-color: var(--c-accent) !important;
             color: var(--c-on-accent) !important;
         }
-
-        /* 
-        - Edit Canvas floating action button warapper on the bottom right
-        - "Ask GPT" floating wrapper */
-        // .bg-token-main-surface-primary {
-        //     background-color: red !important;
-        // }
 
         /* Has to add for the bg of canvas (visible gap or when drag the separator) */
         section.popover.h-full.w-full {
@@ -71,9 +63,7 @@
             }
         }
 
-
         /* @@@@@@@@@ Canvas Edit floating button on bottom right */
-        // main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
         .absolute.z-\[70\].overflow-visible.border.border-token-border-light.transition-colors {
 
             /* Wrapper */
@@ -136,7 +126,6 @@
             }
         }
 
-
         /* ___________ "Ask a ChatGPT" and "Edit or expain..." floating wrapper */
         main .absolute.z-50 {
 
@@ -147,20 +136,11 @@
                     &.bg-token-main-surface-primary {
                         --main-surface-primary: var(--c-surface-2) !important;
                         border: 1px solid hsla(var(--accent-hsl) / .14) !important;
-                        // background-color: hsla(var(--accent-hsl) / .2) !important;
-                        // background-color: var(--c-accent-light)!important;
 
                         /* "Ask a ChatGPT" and toolbar buttons hover states */
                         button[class*="hover:bg-[#f5f5f5]"]:hover {
                             background-color: var(--c-surface-3) !important;
-                            // background-color: var(--c-accent) !important;
-                            // color: var(--c-on-accent) !important;
                         }
-
-                        /* Toolbar buttons like: "Bold", "Italic", "Text style" */
-                        // button.bg-token-main-surface-secondary:has(svg) {
-                        //     // color: var(--c-accent) !important;
-                        // }
                     }
                 }
             }
@@ -182,3 +162,20 @@
 "Port to a language" classes:
 .hover\:bg-gray-100\/75 .dark\:hover\:bg-gray-700 .bg-gray-100\/50 .dark\:bg-gray-700\/50
 .hover:bg-gray-100/75 .dark:hover:bg-gray-700 */
+
+[role="dialog"]:has(div.flex.flex-col.items-stretch.rounded-xl.bg-token-main-surface-primary.shadow-xl > button[class*="hover:bg-token-main-surface-secondary"] > .text-5xl.font-semibold) {
+    padding: calc(var(--p-dialog) * 0.3) !important;
+    border-radius: calc(var(--br-dialog) * 0.5) !important;
+
+    /* Wrapper of the Heading 1, Heading 2, Heading 3 and Body buttons */
+    & > div.rounded-xl.bg-token-main-surface-primary.shadow-xl {
+        box-shadow: none !important;
+    }
+
+    /* "Text style" dialog of: Headings and body text style */
+    button[class*="hover:bg-token-main-surface-secondary"] {
+        &:hover {
+            --main-surface-secondary: var(--c-surface-3) !important;
+        }
+    }
+}

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -68,7 +68,8 @@
 
 
         /*  Canvas Edit floating button on bottom right */
-        main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
+        // main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
+        .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
 
             /* Wrapper */
             &.bg-token-main-surface-primary,
@@ -81,24 +82,28 @@
                 }
             }
 
+            /* Main state floating bg */
             &.bg-token-main-surface-primary {
                 background-color: hsla(var(--accent-hsl) / .2) !important;
                 backdrop-filter: blur(10px);
             }
 
-            &.bg-token-main-surface-secondary {
-                background-color: var(--c-accent-light);
-                // background-color: var(--c-surface-2) !important;
-                // box-shadow: 0 0 5px 2px hsla(var(--accent-hsl) / .2) inset !important;
-            }
+            /* Slider state floating bg: when go into "Adjust the length" and "Reading level" */
+            // &.bg-token-main-surface-secondary {
+            //     background-color: var(--c-accent-light);
+            //     // background-color: var(--c-surface-2) !important;
+            //     // box-shadow: 0 0 5px 2px hsla(var(--accent-hsl) / .2) inset !important;
+            // }
 
             /* Draggable Y-slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
             .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
-                background-color: hsla(var(--accent-hsl) / .35) !important;
+                // background-color: hsla(var(--accent-hsl) / .35) !important;
+                background-color: var(--c-accent-light) !important;
                 color: var(--c-accent) !important;
-                // background-color: hsla(var(--accent-hsl) / .3);
-                // box-shadow: 0 0 0px 2px hsla(var(--accent-hsl) / .3) !important;
-                // color: var(--c-on-accent) !important;
+                // box-shadow: 0 0 20px 10px hsla(var(--accent-hsl) / .4) inset !important;
+                // box-shadow: 0 0 2px 5px hsla(var(--accent-hsl) / .5) !important;
+                box-shadow: 0 0 0 0.65rem hsla(var(--accent-hsl) / 1) !important;
+                // outline: 7px solid hsla(var(--accent-hsl) / .5) !important;
             }
 
             /* SUBMIT CHANGE BUTTONS IN GENERAL */

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -202,9 +202,20 @@
             /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
             .selection-highlight.bg-\[Highlight\],
             // blue highlight of current line when code rewwriting
-            .cm-editor .cm-line.\!bg-\[Highlight\] {
+            .cm-editor .cm-line.\!bg-\[Highlight\],
+            // blue highlight of current selected and about to prompt lines
+            .cm-editor .cm-line span.bg-\[Highlight\] {
                 background-color: var(--c-accent) !important;
                 color: var(--c-on-accent) !important;
+            }
+
+            .cm-editor .cm-line span.bg-\[Highlight\] {
+                // background-color: var(--c-accent) !important;
+
+                &,
+                span {
+                    color: var(--c-on-accent) !important;
+                }
             }
 
             /* Comment section on the right of the text where add comment btn is */

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -28,7 +28,7 @@
     }
 }
 
-/* ______ CM CodeMirror EDITOR */
+/* ______ CODE CANVAS: CM CodeMirror EDITOR */
 .cm-editor {
 
     &,
@@ -71,21 +71,34 @@
         main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
 
             /* Wrapper */
-            &.bg-token-main-surface-primary {
-                background-color: hsla(var(--accent-hsl) / .2) !important;
+            &.bg-token-main-surface-primary,
+            /* .bg-token-main-surface-secondary is for another step, for sliders floating wrappers */
+            &.bg-token-main-surface-secondary {
                 color: var(--c-accent) !important;
-                backdrop-filter: blur(10px);
 
                 .bg-gray-300 {
                     background-color: var(--c-accent) !important;
                 }
             }
 
-            /* Action drag buttons like Y-sliders*/
-            /* Draggable slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
+            &.bg-token-main-surface-primary {
+                background-color: hsla(var(--accent-hsl) / .2) !important;
+                backdrop-filter: blur(10px);
+            }
+
+            &.bg-token-main-surface-secondary {
+                background-color: var(--c-accent-light);
+                // background-color: var(--c-surface-2) !important;
+                // box-shadow: 0 0 5px 2px hsla(var(--accent-hsl) / .2) inset !important;
+            }
+
+            /* Draggable Y-slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
             .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
-                background-color: hsla(var(--accent-hsl) / .2);
+                background-color: hsla(var(--accent-hsl) / .35) !important;
                 color: var(--c-accent) !important;
+                // background-color: hsla(var(--accent-hsl) / .3);
+                // box-shadow: 0 0 0px 2px hsla(var(--accent-hsl) / .3) !important;
+                // color: var(--c-on-accent) !important;
             }
 
             /* SUBMIT CHANGE BUTTONS IN GENERAL */

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -29,6 +29,7 @@
 }
 
 /* ______ CODE CANVAS: CM CodeMirror EDITOR */
+
 .cm-editor {
 
     // .ͼ1p.cm-focused .cm-selectionBackground, .ͼ1p .cm-line::selection, .ͼ1p .cm-selectionLayer .cm-selectionBackground, .ͼ1p .cm-content ::selection {
@@ -63,6 +64,18 @@
         [class^="_modelCursor"]::after {
             color: var(--c-accent);
         }
+    }
+}
+
+/* ______ TEXT CANVAS: ProseMirror EDITOR */
+#prosemirror-editor-container {
+
+    & > div.bg-token-main-surface-primary.ProseMirror {
+        --main-surface-primary: var(--c-bg-cm) !important;
+    }
+
+    .from-token-main-surface-primary {
+        --main-surface-primary: var(--c-bg-cm) !important;
     }
 }
 

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -87,6 +87,17 @@
                 background-color: hsla(var(--accent-hsl) / .2);
                 color: var(--c-accent) !important;
             }
+
+            /* SUBMIT CHANGE BUTTONS IN GENERAL */
+            /* Submit btn for draggable slider btn */
+            .rounded-full.bg-black[draggable],
+            // .rounded-full.bg-black.h-8.w-8,
+            // .rounded-full.bg-black.h-6.w-6,
+            /* Submit on main button "Suggest edits" in Text Canvas or "Code review" in Code Canvas */
+            .rounded-full.bg-black:has(>svg) {
+                background-color: var(--c-accent) !important;
+                color: var(--c-on-accent) !important;
+            }
         }
     }
 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -69,7 +69,7 @@
 
         /*  Canvas Edit floating button on bottom right */
         // main .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
-        .absolute[class*="z-[70]"].overflow-visible.border.border-token-border-light.transition-colors {
+        .absolute.z-\[70\].overflow-visible.border.border-token-border-light.transition-colors {
 
             /* Wrapper */
             &.bg-token-main-surface-primary,
@@ -83,7 +83,8 @@
                 }
             }
 
-            /* Pause primary floating btn while processing */
+            /* Pause primary floating btn while processing: !bg-black !text-white is for light themes, !bg-white, !text-black is for dark */
+            &[class*="!bg-black !text-white"],
             &[class*="!bg-white !text-black"] {
                 background-color: var(--c-accent) !important;
                 color: var(--c-on-accent) !important;

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -87,6 +87,11 @@
 .absolute.left-0.z-20.h-full.overflow-hidden,
 .fixed.inset-0.z-40.overflow-hidden {
 
+    /* Loading screen for Canvas when there is no #codemirror or #prosemirror-editor-container loaded yet */
+    section.popover:has(main [class*="absolute left-0 top-0 h-full w-full rotate-45 bg-gradient-to-r from-transparent via-black/20 to-transparent opacity-50 dark:via-white/5"]) {
+        background-color: var(--c-bg-cm) !important;
+    }
+
     &:has(section.popover main #codemirror, section.popover main #prosemirror-editor-container) {
         .bg-black {
             background-color: var(--c-accent) !important;

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -245,9 +245,10 @@
                 }
 
                 /* Floating balloons, like "1 more edit" */
-                .bg-token-main-surface-primary.border-token-main-surface-tertiary[aria-label="Button to scroll the next edit into view"] {
-                    --main-surface-primary: hsla(var(--accent-hsl) / .12) !important;
-                    border-color: hsla(var(--accent-hsl) / .1) !important;
+                .bg-token-main-surface-primary.border-token-main-surface-tertiary[aria-label^="Button to scroll the next edit into view"] {
+                    --main-surface-primary: hsla(var(--accent-hsl) / .15) !important;
+                    --main-surface-secondary: hsla(var(--accent-hsl) / .3) !important;
+                    border-color: hsla(var(--accent-hsl) / .12) !important;
                     color: var(--c-accent) !important;
                     backdrop-filter: blur(10px);
                 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -42,8 +42,10 @@
     }
 }
 
-/* Canvas with cm-editor showed on the left (when open canvas) */
-.absolute.z-20.h-full.transition-shadow.overflow-hidden.left-0:has(.cm-editor) {
+/* Canvas with cm-editor showed on the left (when open canvas) 
+- .fixed.inset-0.z-40.overflow-hidden:has(section.popover main #codemirror) is for smaller screens (width <= 1000px) */
+.absolute.left-0.z-20.h-full.transition-shadow.left-0.overflow-hidden:has(section.popover main #codemirror),
+.fixed.inset-0.z-40.overflow-hidden:has(section.popover main #codemirror) {
 
     /* Has to add for the bg of canvas (visible gap or when drag the separator) */
     section.popover.h-full.w-full {

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -77,6 +77,7 @@
             &.bg-token-main-surface-secondary {
                 color: var(--c-accent) !important;
 
+                /* dots level in slider */
                 .bg-gray-300 {
                     background-color: var(--c-accent) !important;
                 }
@@ -97,13 +98,7 @@
 
             /* Draggable Y-slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
             .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
-                // background-color: hsla(var(--accent-hsl) / .35) !important;
-                background-color: var(--c-accent-light) !important;
-                color: var(--c-accent) !important;
-                // box-shadow: 0 0 20px 10px hsla(var(--accent-hsl) / .4) inset !important;
-                // box-shadow: 0 0 2px 5px hsla(var(--accent-hsl) / .5) !important;
                 box-shadow: 0 0 0 0.65rem hsla(var(--accent-hsl) / 1) !important;
-                // outline: 7px solid hsla(var(--accent-hsl) / .5) !important;
             }
 
             /* SUBMIT CHANGE BUTTONS IN GENERAL */
@@ -117,10 +112,21 @@
                 color: var(--c-on-accent) !important;
             }
 
-            /* "Port to a language" list */
-            .content-center.overflow-x-hidden [class*="hover:bg-gray-100/"] {
-                background-color: hsla(var(--accent-hsl) / .2) !important;
+            /* "Port to a language" and "Add emoji" list */
+            .content-center.overflow-x-hidden {
+                [class*="dark:hover:bg-gray-700"] {
+
+                    &[class*="dark:bg-gray-700/50"],
+                    &:hover {
+                        background-color: hsla(var(--accent-hsl) / .2) !important;
+                    }
+                }
             }
         }
     }
 }
+
+
+
+/* hover\:bg-gray-100\/75 .dark\:hover\:bg-gray-700 .bg-gray-100\/50 .dark\:bg-gray-700\/50 */
+// hover:bg-gray-100/75 .dark:hover:bg-gray-700

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -1,0 +1,57 @@
+/* ______ Canvas in chat bubble */
+.agent-turn:has([id^="textdoc-message"]) {
+    // --c-bg-pre: var(--c-surface-1);
+    // --c-bg-pre: var(--c-surface-2);
+
+    .popover {
+        --main-surface-primary: var(--c-bg-cm) !important;
+    }
+
+    [id^="textdoc-message"] {
+        will-change: border-color;
+        border: 2px solid hsla(var(--accent-hsl) / .12) !important;
+        transition: border-color .2s;
+
+        /* Gradient on the bottom of code */
+        .absolute.bottom-0.z-20.h-24.w-full.transition-colors {
+            background: linear-gradient(rgba(0, 0, 0, 0), var(--c-bg-cm)) !important;
+        }
+
+        &:hover {
+            border-color: hsla(var(--accent-hsl) / .3) !important;
+        }
+    }
+
+    /* Chat bubble - "Typing" btn when canvas creating */
+    [role="button"].absolute.bottom-3:has(>.loading-shimmer-pure-text) {
+        // --main-surface-primary: red !important;
+    }
+}
+
+/* ______ CM CodeMirror EDITOR */
+.cm-editor {
+
+    &,
+    .cm-gutters {
+        background-color: var(--c-bg-cm) !important;
+    }
+
+    .cm-activeLineGutter {
+        background-color: hsla(var(--accent-hsl) / .2) !important;
+        color: var(--c-accent) !important;
+    }
+}
+
+/* Canvas with cm-editor showed on the left (when open canvas) */
+.absolute.z-20.h-full.transition-shadow.overflow-hidden.left-0:has(.cm-editor) {
+
+    /* Has to add for the bg of canvas (visible gap or when drag the separator) */
+    section.popover.h-full.w-full {
+        background-color: var(--c-bg-cm) !important;
+
+        /* Header of canvas with title, coppy btn */
+        header[class*="@container"] {
+            background-color: var(--c-bg-cm);
+        }
+    }
+}

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -1,41 +1,39 @@
 /* ______ CODE CANVAS: CM CodeMirror EDITOR */
 
-#codemirror {
 
-    .cm-editor {
+.cm-editor {
 
-        // .ͼ1p.cm-focused .cm-selectionBackground, .ͼ1p .cm-line::selection, .ͼ1p .cm-selectionLayer .cm-selectionBackground, .ͼ1p .cm-content ::selection {
-        //     background: #6199ff2f !important;
-        // }
-        .cm-content {
-            caret-color: var(--c-accent) !important;
+    // .ͼ1p.cm-focused .cm-selectionBackground, .ͼ1p .cm-line::selection, .ͼ1p .cm-selectionLayer .cm-selectionBackground, .ͼ1p .cm-content ::selection {
+    //     background: #6199ff2f !important;
+    // }
+    .cm-content {
+        caret-color: var(--c-accent) !important;
 
-            ::selection,
-            .cm-selectionLayer .cm-selectionBackground,
-            // .cm-line span.cm-focused .cm-selectionBackground,
-            .cm-line > *::selection,
-            .cm-line::selection {
-                // background: var(--c-accent) !important;
-                // color: var(--c-on-accent) !important;
-                background: hsla(var(--accent-hsl) / .14) !important;
-                color: var(--c-accent) !important;
-            }
-        }
-
-        &,
-        .cm-gutters {
-            background-color: var(--c-bg-cm) !important;
-        }
-
-        .cm-activeLineGutter {
-            background-color: hsla(var(--accent-hsl) / .2) !important;
+        ::selection,
+        .cm-selectionLayer .cm-selectionBackground,
+        // .cm-line span.cm-focused .cm-selectionBackground,
+        .cm-line > *::selection,
+        .cm-line::selection {
+            // background: var(--c-accent) !important;
+            // color: var(--c-on-accent) !important;
+            background: hsla(var(--accent-hsl) / .14) !important;
             color: var(--c-accent) !important;
         }
+    }
 
-        .cm-line {
-            [class^="_modelCursor"]::after {
-                color: var(--c-accent);
-            }
+    &,
+    .cm-gutters {
+        background-color: var(--c-bg-cm) !important;
+    }
+
+    .cm-activeLineGutter {
+        background-color: hsla(var(--accent-hsl) / .2) !important;
+        color: var(--c-accent) !important;
+    }
+
+    .cm-line {
+        [class^="_modelCursor"]::after {
+            color: var(--c-accent);
         }
     }
 }
@@ -46,6 +44,12 @@
     & > div.bg-token-main-surface-primary.ProseMirror,
     .from-token-main-surface-primary {
         --main-surface-primary: var(--c-bg-cm) !important;
+    }
+
+    .cm-editor {
+        background-color: var(--c-surface-2) !important;
+        border-radius: var(--br);
+        border: 1px solid var(--c-border);
     }
 }
 

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -183,157 +183,157 @@
                     }
                 }
             }
-        }
 
-        /* @@@@@@@@@ Canvas Edit floating button on bottom right */
-        .absolute.z-\[70\].overflow-visible.border.border-token-border-light.transition-colors {
+            /* @@@@@@@@@ Canvas Edit floating button on bottom right */
+            .absolute.z-\[70\].overflow-visible.border.border-token-border-light.transition-colors {
 
-            /* Wrapper */
-            &.bg-token-main-surface-primary,
-            /* .bg-token-main-surface-secondary is for another step, for sliders floating wrappers */
-            &.bg-token-main-surface-secondary {
-                color: var(--c-accent) !important;
+                /* Wrapper */
+                &.bg-token-main-surface-primary,
+                /* .bg-token-main-surface-secondary is for another step, for sliders floating wrappers */
+                &.bg-token-main-surface-secondary {
+                    color: var(--c-accent) !important;
 
-                /* dots level in slider */
-                .bg-gray-300 {
-                    background-color: var(--c-accent) !important;
+                    /* dots level in slider */
+                    .bg-gray-300 {
+                        background-color: var(--c-accent) !important;
+                    }
                 }
-            }
 
-            /* Pause primary floating btn while processing: !bg-black !text-white is for light themes, !bg-white, !text-black is for dark */
-            &[class*="!bg-black !text-white"],
-            &[class*="!bg-white !text-black"] {
-                background-color: var(--c-accent) !important;
-                color: var(--c-on-accent) !important;
-            }
+                /* Pause primary floating btn while processing: !bg-black !text-white is for light themes, !bg-white, !text-black is for dark */
+                &[class*="!bg-black !text-white"],
+                &[class*="!bg-white !text-black"] {
+                    background-color: var(--c-accent) !important;
+                    color: var(--c-on-accent) !important;
+                }
 
-            /* Main state floating bg */
-            &.bg-token-main-surface-primary {
-                background-color: hsla(var(--accent-hsl) / .2) !important;
-                backdrop-filter: blur(10px);
-            }
+                /* Main state floating bg */
+                &.bg-token-main-surface-primary {
+                    background-color: hsla(var(--accent-hsl) / .2) !important;
+                    backdrop-filter: blur(10px);
+                }
 
-            /* Draggable Y-slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
-            .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
-                box-shadow: 0 0 0 0.65rem hsla(var(--accent-hsl) / 1) !important;
-            }
+                /* Draggable Y-slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
+                .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
+                    box-shadow: 0 0 0 0.65rem hsla(var(--accent-hsl) / 1) !important;
+                }
 
-            /* SUBMIT CHANGE BUTTONS IN GENERAL */
-            /* Submit btn for draggable slider btn */
-            .rounded-full.bg-black[draggable],
-            // .rounded-full.bg-black.h-8.w-8,
-            // .rounded-full.bg-black.h-6.w-6,
-            /* Submit on main button "Suggest edits" in Text Canvas or "Code review" in Code Canvas */
-            .rounded-full.bg-black:has(>svg) {
-                background-color: var(--c-accent) !important;
-                color: var(--c-on-accent) !important;
-            }
+                /* SUBMIT CHANGE BUTTONS IN GENERAL */
+                /* Submit btn for draggable slider btn */
+                .rounded-full.bg-black[draggable],
+                // .rounded-full.bg-black.h-8.w-8,
+                // .rounded-full.bg-black.h-6.w-6,
+                /* Submit on main button "Suggest edits" in Text Canvas or "Code review" in Code Canvas */
+                .rounded-full.bg-black:has(>svg) {
+                    background-color: var(--c-accent) !important;
+                    color: var(--c-on-accent) !important;
+                }
 
-            /* "Port to a language" and "Add emoji" list */
-            .content-center.overflow-x-hidden {
-                [class*="dark:hover:bg-gray-700"] {
+                /* "Port to a language" and "Add emoji" list */
+                .content-center.overflow-x-hidden {
+                    [class*="dark:hover:bg-gray-700"] {
 
-                    &[class*="dark:bg-gray-700/50"],
-                    &:hover {
-                        background-color: hsla(var(--accent-hsl) / .2) !important;
+                        &[class*="dark:bg-gray-700/50"],
+                        &:hover {
+                            background-color: hsla(var(--accent-hsl) / .2) !important;
+                        }
                     }
                 }
             }
-        }
 
-        main {
+            main {
 
-            /* ___________ "Ask a ChatGPT" and "Edit or expain..." floating wrapper */
-            .absolute.z-50 {
+                /* ___________ "Ask a ChatGPT" and "Edit or expain..." floating wrapper */
+                .absolute.z-50 {
 
-                /* "Ask a ChatGPT" and toolbar wrapper */
-                &:has(> .h-10[role="toolbar"]) {
-                    .h-10[role="toolbar"] {
+                    /* "Ask a ChatGPT" and toolbar wrapper */
+                    &:has(> .h-10[role="toolbar"]) {
+                        .h-10[role="toolbar"] {
 
-                        &.bg-token-main-surface-primary {
-                            --main-surface-primary: var(--c-surface-2) !important;
-                            border: 1px solid hsla(var(--accent-hsl) / .14) !important;
+                            &.bg-token-main-surface-primary {
+                                --main-surface-primary: var(--c-surface-2) !important;
+                                border: 1px solid hsla(var(--accent-hsl) / .14) !important;
 
-                            /* "Ask a ChatGPT" and toolbar buttons hover states */
-                            button[class*="hover:bg-[#f5f5f5]"]:hover {
-                                background-color: var(--c-surface-3) !important;
+                                /* "Ask a ChatGPT" and toolbar buttons hover states */
+                                button[class*="hover:bg-[#f5f5f5]"]:hover {
+                                    background-color: var(--c-surface-3) !important;
+                                }
                             }
+                        }
+                    }
+
+                    /* "Edit or explain" wrapper */
+                    .relative.bg-token-main-surface-primary:has(>textarea[aria-placeholder^="Edit or explain"]) {
+                        background-color: hsla(var(--accent-hsl) / .1) !important;
+
+                        /* "Edit or explain" field overlay */
+                        .backdrop-saturate-25 {
+                            background-color: hsla(var(--accent-hsl) / .1) !important;
                         }
                     }
                 }
 
-                /* "Edit or explain" wrapper */
-                .relative.bg-token-main-surface-primary:has(>textarea[aria-placeholder^="Edit or explain"]) {
-                    background-color: hsla(var(--accent-hsl) / .1) !important;
+                /* Floating balloons, like "1 more edit" */
+                .bg-token-main-surface-primary.border-token-main-surface-tertiary[aria-label="Button to scroll the next edit into view"] {
+                    --main-surface-primary: hsla(var(--accent-hsl) / .12) !important;
+                    border-color: hsla(var(--accent-hsl) / .1) !important;
+                    color: var(--c-accent) !important;
+                    backdrop-filter: blur(10px);
+                }
 
-                    /* "Edit or explain" field overlay */
-                    .backdrop-saturate-25 {
-                        background-color: hsla(var(--accent-hsl) / .1) !important;
+
+                /* Blue Highlight when hover text to add a comment in Text Canvas */
+                [class*="dark:after:bg-[Highlight]"] {
+                    &::after {
+                        background-color: hsla(var(--accent-hsl) / .15) !important;
+                        border: 1px solid hsla(var(--accent-hsl) / .15) !important;
                     }
                 }
-            }
 
-            /* Floating balloons, like "1 more edit" */
-            .bg-token-main-surface-primary.border-token-main-surface-tertiary[aria-label="Button to scroll the next edit into view"] {
-                --main-surface-primary: hsla(var(--accent-hsl) / .12) !important;
-                border-color: hsla(var(--accent-hsl) / .1) !important;
-                color: var(--c-accent) !important;
-                backdrop-filter: blur(10px);
-            }
+                /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
+                .selection-highlight.bg-\[Highlight\],
+                // Text Canvas: blue highlight when text started to proccesing "Apply" from GPT comment
+                .selection-highlight.\!bg-\[Highlight\],
+                // Code Canvas: blue highlight of current line when code rewwriting
+                .cm-editor .cm-line.\!bg-\[Highlight\],
 
-
-            /* Blue Highlight when hover text to add a comment in Text Canvas */
-            [class*="dark:after:bg-[Highlight]"] {
-                &::after {
-                    background-color: hsla(var(--accent-hsl) / .15) !important;
-                    border: 1px solid hsla(var(--accent-hsl) / .15) !important;
-                }
-            }
-
-            /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
-            .selection-highlight.bg-\[Highlight\],
-            // Text Canvas: blue highlight when text started to proccesing "Apply" from GPT comment
-            .selection-highlight.\!bg-\[Highlight\],
-            // Code Canvas: blue highlight of current line when code rewwriting
-            .cm-editor .cm-line.\!bg-\[Highlight\],
-
-            // Code Canvas: blue highlight of current selected and about to prompt lines
-            .cm-editor .cm-line span.bg-\[Highlight\] {
-                background-color: var(--c-accent) !important;
-                color: var(--c-on-accent) !important;
-            }
-
-            .cm-editor .cm-line span.bg-\[Highlight\],
-            // Code Canvas: Hc-blue line of current processing line
-            .cm-editor .cm-line.\!bg-\[Highlight\] span {
-                // background-color: var(--c-accent) !important;
-
-                &,
-                span {
+                // Code Canvas: blue highlight of current selected and about to prompt lines
+                .cm-editor .cm-line span.bg-\[Highlight\] {
+                    background-color: var(--c-accent) !important;
                     color: var(--c-on-accent) !important;
                 }
-            }
 
-            /* Comment section on the right of the text where add comment btn is */
-            [data-block-comment-launcher] button {
-                .text-gray-400 {
-                    svg {
-                        color: var(--c-accent) !important;
+                .cm-editor .cm-line span.bg-\[Highlight\],
+                // Code Canvas: Hc-blue line of current processing line
+                .cm-editor .cm-line.\!bg-\[Highlight\] span {
+                    // background-color: var(--c-accent) !important;
+
+                    &,
+                    span {
+                        color: var(--c-on-accent) !important;
                     }
                 }
-            }
 
-            .cm-editor {
-
-                /* Code Canvas of yet non-edited lines while code is rewriting ("Add logs", "Add comments") */
-                .streaming-line-overlay {
-                    &.before\:bg-white\/50:before {
-                        background-color: var(--c-bg-cm) !important;
-                        opacity: 0.85;
+                /* Comment section on the right of the text where add comment btn is */
+                [data-block-comment-launcher] button {
+                    .text-gray-400 {
+                        svg {
+                            color: var(--c-accent) !important;
+                        }
                     }
+                }
 
-                    &.\:bg-white\/50 {
-                        background-color: var(--c-bg-cm) !important;
+                .cm-editor {
+
+                    /* Code Canvas of yet non-edited lines while code is rewriting ("Add logs", "Add comments") */
+                    .streaming-line-overlay {
+                        &.before\:bg-white\/50:before {
+                            background-color: var(--c-bg-cm) !important;
+                            opacity: 0.85;
+                        }
+
+                        &.\:bg-white\/50 {
+                            background-color: var(--c-bg-cm) !important;
+                        }
                     }
                 }
             }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -406,3 +406,14 @@
         }
     }
 }
+
+
+/* Hide the floating button when Canvas is opened */
+body:has(.absolute.z-20.h-full.transition-shadow.overflow-hidden.left-0 section.popover main #codemirror),
+body:has(.absolute.z-20.h-full.transition-shadow.overflow-hidden.left-0 section.popover main #prosemirror-editor-container),
+body:has(.absolute.z-20.h-full.transition-shadow.overflow-hidden.left-0 section.popover main [class*="absolute left-0 top-0 h-full w-full rotate-45 bg-gradient-to-r from-transparent via-black/20 to-transparent opacity-50 dark:via-white/5"]) {
+    .gpth__floating {
+        opacity: 0;
+        pointer-events: none;
+    }
+}

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -157,6 +157,14 @@
                     }
                 }
             }
+
+            /* Floating balloons, like "1 more edit" */
+            .bg-token-main-surface-primary.border-token-main-surface-tertiary[aria-label="Button to scroll the next edit into view"] {
+                --main-surface-primary: hsla(var(--accent-hsl) / .12) !important;
+                border-color: hsla(var(--accent-hsl) / .1) !important;
+                color: var(--c-accent) !important;
+                backdrop-filter: blur(10px);
+            }
         }
     }
 }
@@ -188,6 +196,7 @@
 .hover\:bg-gray-100\/75 .dark\:hover\:bg-gray-700 .bg-gray-100\/50 .dark\:bg-gray-700\/50
 .hover:bg-gray-100/75 .dark:hover:bg-gray-700 */
 
+/* Select a "Text style" dialog: Heading 1 | Heading 2 | Heading 3 | Body radix dialog */
 [role="dialog"]:has(div.flex.flex-col.items-stretch.rounded-xl.bg-token-main-surface-primary.shadow-xl > button[class*="hover:bg-token-main-surface-secondary"] > .text-5xl.font-semibold) {
     padding: calc(var(--p-dialog) * 0.3) !important;
     border-radius: calc(var(--br-dialog) * 0.5) !important;

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -100,6 +100,47 @@
             /* Header of canvas with title, coppy btn */
             header[class*="@container"] {
                 background-color: var(--c-bg-cm);
+
+                /* Main Canvas title */
+                h2.truncate.text-lg.text-gray-700 {
+                    color: var(--c-accent) !important;
+                }
+
+                /* Previous, Before, Copy btns in header */
+                button.h-10[class*="enabled:hover:bg-token-main-surface-secondary"] {
+                    --main-surface-secondary: var(--c-surface-3) !important;
+
+                    &:disabled {
+                        color: var(--c-subtext-2) !important;
+
+                        svg {
+                            transition: none !important;
+                        }
+
+                        &:hover {
+                            background-color: none !important;
+
+                            svg {
+                                transform: none !important;
+                            }
+                        }
+                    }
+                }
+
+                /* History of changes btn when active/clicked  */
+                button.h-10[class*="bg-blue-400/15"] {
+                    @extend .btn-primary;
+                }
+
+                /* "Run" code button */
+                button.rounded-full.bg-token-main-surface-primary {
+                    @extend .btn-secondary;
+                }
+
+                /* User Profile btn */
+                button[aria-label="Open Profile Menu"] {
+                    --main-surface-secondary: var(--c-surface-3) !important
+                }
             }
 
             /* Resizing line */

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -42,18 +42,28 @@
     }
 }
 
-/* Canvas with cm-editor showed on the left (when open canvas) 
-- .fixed.inset-0.z-40.overflow-hidden:has(section.popover main #codemirror) is for smaller screens (width <= 1000px) */
-.absolute.left-0.z-20.h-full.transition-shadow.left-0.overflow-hidden:has(section.popover main #codemirror),
-.fixed.inset-0.z-40.overflow-hidden:has(section.popover main #codemirror) {
+/* Canvas with CodeMirror (for code) and ProseMirror (for text) showed on the left (when open canvas) 
+- .fixed.inset-0.z-40.overflow-hidden is for smaller screens (width <= 1000px) */
+.absolute.left-0.z-20.h-full.overflow-hidden,
+.fixed.inset-0.z-40.overflow-hidden {
 
-    /* Has to add for the bg of canvas (visible gap or when drag the separator) */
-    section.popover.h-full.w-full {
-        background-color: var(--c-bg-cm) !important;
+    &:has(section.popover main #codemirror, section.popover main #prosemirror-editor-container) {
 
-        /* Header of canvas with title, coppy btn */
-        header[class*="@container"] {
-            background-color: var(--c-bg-cm);
+        /* 
+        - Edit Canvas floating action button warapper on the bottom right
+        - "Ask GPT" floating wrapper */
+        // .bg-token-main-surface-primary {
+        //     background-color: red !important;
+        // }
+
+        /* Has to add for the bg of canvas (visible gap or when drag the separator) */
+        section.popover.h-full.w-full {
+            background-color: var(--c-bg-cm) !important;
+
+            /* Header of canvas with title, coppy btn */
+            header[class*="@container"] {
+                background-color: var(--c-bg-cm);
+            }
         }
     }
 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -337,6 +337,22 @@
                     }
                 }
             }
+
+            /* width <= 1000px: User chat in Code Canvas when "Ask GPT" */
+            /* width <= 1000px: Gradient oko chata na light temi */
+            .bg-vert-light-gradient {
+                background-image: linear-gradient(180deg, #fff0 13.94%, var(--c-bg-cm) 54.73%);
+            }
+
+            /* width <= 1000px: Gradient oko chata na dark temi */
+            [class*="dark:from-token-main-surface-primary"] {
+                --main-surface-primary: var(--c-bg-cm) !important;
+            }
+
+            /* width <= 1000px: Poruke usera u Code Canvas */
+            .bg-token-message-surface {
+                background-color: var(--c-bg-msg-user) !important;
+            }
         }
     }
 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -53,8 +53,13 @@
             color: var(--c-on-accent) !important;
         }
 
-        /* Has to add for the bg of canvas (visible gap or when drag the separator) */
+        /* TODO: Has to add for the bg of Canvas (visible gap or when drag the separator). Btw, when opening canvas, when there is skeleton waiting, the bg is not --c-bg-cm for this section.bg-token-main-surface-primary */
         section.popover.h-full.w-full {
+            // &.bg-token-main-surface-primary {
+            //     --main-surface-primary: var(--c-bg-cm) !important;
+            //     // background-color: var(--c-bg-cm) !important;
+            // }
+
             background-color: var(--c-bg-cm) !important;
 
             /* Header of canvas with title, coppy btn */
@@ -164,6 +169,21 @@
                 border-color: hsla(var(--accent-hsl) / .1) !important;
                 color: var(--c-accent) !important;
                 backdrop-filter: blur(10px);
+            }
+
+
+            /* Blue Highlight when hover text to add a comment in Text Canvas */
+            [class*="dark:after:bg-[Highlight]"] {
+                &::after {
+                    background-color: hsla(var(--accent-hsl) / .12) !important;
+                    border: 1px solid hsla(var(--accent-hsl) / .12) !important;
+                }
+            }
+
+            /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
+            .selection-highlight.bg-\[Highlight\] {
+                background-color: var(--c-accent) !important;
+                color: var(--c-on-accent) !important;
             }
         }
     }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -83,6 +83,12 @@
                 }
             }
 
+            /* Pause primary floating btn while processing */
+            &[class*="!bg-white !text-black"] {
+                background-color: var(--c-accent) !important;
+                color: var(--c-on-accent) !important;
+            }
+
             /* Main state floating bg */
             &.bg-token-main-surface-primary {
                 background-color: hsla(var(--accent-hsl) / .2) !important;

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -31,6 +31,24 @@
 /* ______ CODE CANVAS: CM CodeMirror EDITOR */
 .cm-editor {
 
+    // .ͼ1p.cm-focused .cm-selectionBackground, .ͼ1p .cm-line::selection, .ͼ1p .cm-selectionLayer .cm-selectionBackground, .ͼ1p .cm-content ::selection {
+    //     background: #6199ff2f !important;
+    // }
+    .cm-content {
+        caret-color: var(--c-accent) !important;
+
+        ::selection,
+        .cm-selectionLayer .cm-selectionBackground,
+        .cm-line span.cm-focused .cm-selectionBackground,
+        .cm-line > span::selection,
+        .cm-line::selection {
+            // background: var(--c-accent) !important;
+            // color: var(--c-on-accent) !important;
+            background: hsla(var(--accent-hsl) / .14) !important;
+            color: var(--c-accent) !important;
+        }
+    }
+
     &,
     .cm-gutters {
         background-color: var(--c-bg-cm) !important;
@@ -59,6 +77,7 @@
             //     --main-surface-primary: var(--c-bg-cm) !important;
             //     // background-color: var(--c-bg-cm) !important;
             // }
+
 
             background-color: var(--c-bg-cm) !important;
 
@@ -181,7 +200,9 @@
             }
 
             /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
-            .selection-highlight.bg-\[Highlight\] {
+            .selection-highlight.bg-\[Highlight\],
+            // blue highlight of current line when code rewwriting
+            .cm-editor .cm-line.\!bg-\[Highlight\] {
                 background-color: var(--c-accent) !important;
                 color: var(--c-on-accent) !important;
             }
@@ -191,6 +212,17 @@
                 .text-gray-400 {
                     svg {
                         color: var(--c-accent) !important;
+                    }
+                }
+            }
+
+            .cm-editor {
+
+                /* Code Canvas while code rewriting */
+                .streaming-line-overlay {
+                    .before\:bg-white\/50:before {
+                        background-color: var(--c-bg-cm) !important;
+                        opacity: 0.6;
                     }
                 }
             }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -98,6 +98,11 @@
                 background-color: var(--c-accent) !important;
                 color: var(--c-on-accent) !important;
             }
+
+            /* "Port to a language" list */
+            .content-center.overflow-x-hidden [class*="hover:bg-gray-100/"] {
+                background-color: hsla(var(--accent-hsl) / .2) !important;
+            }
         }
     }
 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -39,8 +39,8 @@
 
         ::selection,
         .cm-selectionLayer .cm-selectionBackground,
-        .cm-line span.cm-focused .cm-selectionBackground,
-        .cm-line > span::selection,
+        // .cm-line span.cm-focused .cm-selectionBackground,
+        .cm-line > *::selection,
         .cm-line::selection {
             // background: var(--c-accent) !important;
             // color: var(--c-on-accent) !important;

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -97,14 +97,14 @@
         section.popover.h-full.w-full {
             background-color: var(--c-bg-cm) !important;
 
-            /* Resizing line */
-            .cursor-ns-resize.bg-token-text-quaternary {
-                background-color: hsla(var(--accent-hsl) / .5) !important;
-            }
-
             /* Header of canvas with title, coppy btn */
             header[class*="@container"] {
                 background-color: var(--c-bg-cm);
+            }
+
+            /* Resizing line */
+            .cursor-ns-resize.bg-token-text-quaternary {
+                background-color: hsla(var(--accent-hsl) / .5) !important;
             }
 
             /* Borders in console */

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -1,33 +1,3 @@
-/* ______ Canvas in chat bubble */
-.agent-turn:has([id^="textdoc-message"]) {
-    // --c-bg-pre: var(--c-surface-1);
-    // --c-bg-pre: var(--c-surface-2);
-
-    .popover {
-        --main-surface-primary: var(--c-bg-cm) !important;
-    }
-
-    [id^="textdoc-message"] {
-        will-change: border-color;
-        border: 2px solid hsla(var(--accent-hsl) / .12) !important;
-        transition: border-color .2s;
-
-        /* Gradient on the bottom of code */
-        .absolute.bottom-0.z-20.h-24.w-full.transition-colors {
-            background: linear-gradient(rgba(0, 0, 0, 0), var(--c-bg-cm)) !important;
-        }
-
-        &:hover {
-            border-color: hsla(var(--accent-hsl) / .3) !important;
-        }
-    }
-
-    /* Chat bubble - "Typing" btn when canvas creating */
-    [role="button"].absolute.bottom-3:has(>.loading-shimmer-pure-text) {
-        // --main-surface-primary: red !important;
-    }
-}
-
 /* ______ CODE CANVAS: CM CodeMirror EDITOR */
 
 #codemirror {
@@ -73,10 +43,7 @@
 /* ______ TEXT CANVAS: ProseMirror EDITOR */
 #prosemirror-editor-container {
 
-    & > div.bg-token-main-surface-primary.ProseMirror {
-        --main-surface-primary: var(--c-bg-cm) !important;
-    }
-
+    & > div.bg-token-main-surface-primary.ProseMirror,
     .from-token-main-surface-primary {
         --main-surface-primary: var(--c-bg-cm) !important;
     }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -81,7 +81,12 @@
                 }
             }
 
-
+            /* Action drag buttons like Y-sliders*/
+            /* Draggable slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
+            .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
+                background-color: hsla(var(--accent-hsl) / .2);
+                color: var(--c-accent) !important;
+            }
         }
     }
 }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -30,39 +30,42 @@
 
 /* ______ CODE CANVAS: CM CodeMirror EDITOR */
 
-.cm-editor {
+#codemirror {
 
-    // .ͼ1p.cm-focused .cm-selectionBackground, .ͼ1p .cm-line::selection, .ͼ1p .cm-selectionLayer .cm-selectionBackground, .ͼ1p .cm-content ::selection {
-    //     background: #6199ff2f !important;
-    // }
-    .cm-content {
-        caret-color: var(--c-accent) !important;
+    .cm-editor {
 
-        ::selection,
-        .cm-selectionLayer .cm-selectionBackground,
-        // .cm-line span.cm-focused .cm-selectionBackground,
-        .cm-line > *::selection,
-        .cm-line::selection {
-            // background: var(--c-accent) !important;
-            // color: var(--c-on-accent) !important;
-            background: hsla(var(--accent-hsl) / .14) !important;
+        // .ͼ1p.cm-focused .cm-selectionBackground, .ͼ1p .cm-line::selection, .ͼ1p .cm-selectionLayer .cm-selectionBackground, .ͼ1p .cm-content ::selection {
+        //     background: #6199ff2f !important;
+        // }
+        .cm-content {
+            caret-color: var(--c-accent) !important;
+
+            ::selection,
+            .cm-selectionLayer .cm-selectionBackground,
+            // .cm-line span.cm-focused .cm-selectionBackground,
+            .cm-line > *::selection,
+            .cm-line::selection {
+                // background: var(--c-accent) !important;
+                // color: var(--c-on-accent) !important;
+                background: hsla(var(--accent-hsl) / .14) !important;
+                color: var(--c-accent) !important;
+            }
+        }
+
+        &,
+        .cm-gutters {
+            background-color: var(--c-bg-cm) !important;
+        }
+
+        .cm-activeLineGutter {
+            background-color: hsla(var(--accent-hsl) / .2) !important;
             color: var(--c-accent) !important;
         }
-    }
 
-    &,
-    .cm-gutters {
-        background-color: var(--c-bg-cm) !important;
-    }
-
-    .cm-activeLineGutter {
-        background-color: hsla(var(--accent-hsl) / .2) !important;
-        color: var(--c-accent) !important;
-    }
-
-    .cm-line {
-        [class^="_modelCursor"]::after {
-            color: var(--c-accent);
+        .cm-line {
+            [class^="_modelCursor"]::after {
+                color: var(--c-accent);
+            }
         }
     }
 }
@@ -92,17 +95,29 @@
 
         /* TODO: Has to add for the bg of Canvas (visible gap or when drag the separator). Btw, when opening canvas, when there is skeleton waiting, the bg is not --c-bg-cm for this section.bg-token-main-surface-primary */
         section.popover.h-full.w-full {
-            // &.bg-token-main-surface-primary {
-            //     --main-surface-primary: var(--c-bg-cm) !important;
-            //     // background-color: var(--c-bg-cm) !important;
-            // }
-
-
             background-color: var(--c-bg-cm) !important;
+
+            /* Canvas wrapper, this is also bg color for the console */
+            /* &,
+            .bg-token-main-surface-primary {
+                --main-surface-primary: var(--c-bg-cm) !important;
+                // background-color: var(--c-bg-cm) !important;
+            } */
+
+            /* Resizing line */
+            .cursor-ns-resize.bg-token-text-quaternary {
+                background-color: hsla(var(--accent-hsl) / .4) !important;
+            }
 
             /* Header of canvas with title, coppy btn */
             header[class*="@container"] {
                 background-color: var(--c-bg-cm);
+            }
+
+            /* Borders in console */
+            .border-token-border-xlight {
+                --border-xlight: hsla(var(--accent-hsl) / .05) !important;
+                // border-color: var(--border-xlight);
             }
         }
 
@@ -133,13 +148,6 @@
                 background-color: hsla(var(--accent-hsl) / .2) !important;
                 backdrop-filter: blur(10px);
             }
-
-            /* Slider state floating bg: when go into "Adjust the length" and "Reading level" */
-            // &.bg-token-main-surface-secondary {
-            //     background-color: var(--c-accent-light);
-            //     // background-color: var(--c-surface-2) !important;
-            //     // box-shadow: 0 0 5px 2px hsla(var(--accent-hsl) / .2) inset !important;
-            // }
 
             /* Draggable Y-slider btn like: "Adjust the length" and "Reading level" in ProseMirror (text canvas) */
             .cursor-grab.rounded-full.bg-token-main-surface-primary[draggable] {
@@ -261,6 +269,42 @@
                     &.\:bg-white\/50 {
                         background-color: var(--c-bg-cm) !important;
                     }
+                }
+            }
+        }
+
+
+        /* Code Canvas: Console when "Run" Python code */
+        section > .relative:has(>.cursor-ns-resize) {
+
+            // Console bg
+            .bg-token-main-surface-primary {
+                --main-surface-primary: var(--c-bg-cm) !important;
+                // background-color: var(--c-bg-cm) !important;
+            }
+
+            /* Da obrisemo border za "Console" header jer je bila neka ruzna bela samo za njega */
+            // .border-token-border-xlight:not(.font-mono) {
+            //     border: none !important;
+            // }
+
+            .sticky.top-0.z-10.font-mono.text-sm[class*="dark:hover:bg-gray-700"] {
+                &:hover {
+                    background-color: var(--c-surface-2) !important;
+                }
+            }
+
+            button[as="button"].btn.btn-ghost.btn-small.aspect-square.\!p-1:has(svg) {
+                color: var(--c-accent) !important;
+            }
+
+            /* Error output in consoles */
+            .font-mono[class*="hover:bg-red-500/10"] {
+                background-color: transparent !important;
+                border: none !important;
+
+                &:hover {
+                    background-color: hsla(var(--danger-hsl) / .11) !important;
                 }
             }
         }

--- a/src/sass/elements/_canvas.scss
+++ b/src/sass/elements/_canvas.scss
@@ -58,6 +58,12 @@
         background-color: hsla(var(--accent-hsl) / .2) !important;
         color: var(--c-accent) !important;
     }
+
+    .cm-line {
+        [class^="_modelCursor"]::after {
+            color: var(--c-accent);
+        }
+    }
 }
 
 /* Canvas with CodeMirror (for code) and ProseMirror (for text) showed on the left (when open canvas) 
@@ -201,15 +207,18 @@
 
             /* Selected text for commenting, when we click on comment icon in Text Canvas and "Edit or explain" prompt showed */
             .selection-highlight.bg-\[Highlight\],
-            // blue highlight of current line when code rewwriting
+            // Code Canvas: blue highlight of current line when code rewwriting
             .cm-editor .cm-line.\!bg-\[Highlight\],
-            // blue highlight of current selected and about to prompt lines
+
+            // Code Canvas: blue highlight of current selected and about to prompt lines
             .cm-editor .cm-line span.bg-\[Highlight\] {
                 background-color: var(--c-accent) !important;
                 color: var(--c-on-accent) !important;
             }
 
-            .cm-editor .cm-line span.bg-\[Highlight\] {
+            .cm-editor .cm-line span.bg-\[Highlight\],
+            // Code Canvas: Hc-blue line of current processing line
+            .cm-editor .cm-line.\!bg-\[Highlight\] span {
                 // background-color: var(--c-accent) !important;
 
                 &,
@@ -229,11 +238,15 @@
 
             .cm-editor {
 
-                /* Code Canvas while code rewriting */
+                /* Code Canvas of yet non-edited lines while code is rewriting ("Add logs", "Add comments") */
                 .streaming-line-overlay {
-                    .before\:bg-white\/50:before {
+                    &.before\:bg-white\/50:before {
                         background-color: var(--c-bg-cm) !important;
-                        opacity: 0.6;
+                        opacity: 0.85;
+                    }
+
+                    &.\:bg-white\/50 {
+                        background-color: var(--c-bg-cm) !important;
                     }
                 }
             }

--- a/src/sass/elements/_chats-textarea-max-width.scss
+++ b/src/sass/elements/_chats-textarea-max-width.scss
@@ -1,18 +1,20 @@
 // main:has(#prompt-textarea) [class*='lg:max-w-[40rem]'] {
 // main:has(#prompt-textarea) [class*="xl:max-w-[48rem]"] {
 main:has(#composer-background) {
+	// container: inline-size;
+
 	.px-3.text-base.m-auto {
 		// padding-left: var(--px-chat-bubble-edge-gap) !important;
 		// padding-right: var(--px-chat-bubble-edge-gap) !important;
 
 		/* Only textarea wrapper */
 		.mx-auto.flex.flex-1.text-base:has(>form) {
-			max-width: var(--w_prompt_textarea) !important;
+			max-width: var(--w_prompt_textarea);
 
-			// @include container('md') {
-			// 	border: 1px solid green !important;
-			// 	--w_prompt_textarea: 100%;
-			// }
+			@include container('md') {
+				--w_prompt_textarea: 100%;
+				// border: 1px solid greenyellow !important;
+			}
 
 			/* TODO This element causes weird empty space before prompt field which makes prompt fields visually unshifted or misaligned. The best would be to display:none, but idk if that would be filled with some important content in the future. So I use :empty to remove it only when this element is without any content. */
 			& > div.flex.justify-center:has(~form):empty {

--- a/src/sass/elements/_chats-textarea-max-width.scss
+++ b/src/sass/elements/_chats-textarea-max-width.scss
@@ -2,12 +2,17 @@
 // main:has(#prompt-textarea) [class*="xl:max-w-[48rem]"] {
 main:has(#composer-background) {
 	.px-3.text-base.m-auto {
-		padding-left: var(--px-chat-bubble-edge-gap) !important;
-		padding-right: var(--px-chat-bubble-edge-gap) !important;
+		// padding-left: var(--px-chat-bubble-edge-gap) !important;
+		// padding-right: var(--px-chat-bubble-edge-gap) !important;
 
 		/* Only textarea wrapper */
 		.mx-auto.flex.flex-1.text-base:has(>form) {
 			max-width: var(--w_prompt_textarea) !important;
+
+			// @include container('md') {
+			// 	border: 1px solid green !important;
+			// 	--w_prompt_textarea: 100%;
+			// }
 
 			/* TODO This element causes weird empty space before prompt field which makes prompt fields visually unshifted or misaligned. The best would be to display:none, but idk if that would be filled with some important content in the future. So I use :empty to remove it only when this element is without any content. */
 			& > div.flex.justify-center:has(~form):empty {

--- a/src/sass/elements/_dialogs.scss
+++ b/src/sass/elements/_dialogs.scss
@@ -1,7 +1,7 @@
 /* ===================== DIAOGS ====================  
-not(> [data-comment-id]) - dialog without code comment like in "Run" python code console	
+not(> [data-comment-id]) - dialog without code comment like in "Run" python code console ("Fix bug")
 */
-[role='dialog']:not(> [data-comment-id]) {
+[role='dialog']:not(> div[data-comment-id]) {
 	padding: var(--p-dialog) !important;
 	background-color: var(--c-bg-dialog) !important;
 	border-radius: var(--br-dialog) !important;
@@ -548,8 +548,6 @@ not(> [data-comment-id]) - dialog without code comment like in "Run" python code
 		}
 
 	}
-
-	&:has(> [data-comment-id]) {}
 
 }
 

--- a/src/sass/elements/_dialogs.scss
+++ b/src/sass/elements/_dialogs.scss
@@ -1,7 +1,7 @@
 /* ===================== DIAOGS ====================  
 not(> [data-comment-id]) - dialog without code comment like in "Run" python code console ("Fix bug")
 */
-[role='dialog']:not(> div[data-comment-id]) {
+[role='dialog']:not([data-comment-id]) {
 	padding: var(--p-dialog) !important;
 	background-color: var(--c-bg-dialog) !important;
 	border-radius: var(--br-dialog) !important;

--- a/src/sass/elements/_dialogs.scss
+++ b/src/sass/elements/_dialogs.scss
@@ -1,5 +1,7 @@
-/* Dialogs - Settings  */
-[role='dialog'] {
+/* ===================== DIAOGS ====================  
+not(> [data-comment-id]) - dialog without code comment like in "Run" python code console	
+*/
+[role='dialog']:not(> [data-comment-id]) {
 	padding: var(--p-dialog) !important;
 	background-color: var(--c-bg-dialog) !important;
 	border-radius: var(--br-dialog) !important;
@@ -83,7 +85,7 @@
 		text-transform: uppercase;
 	}
 
-	/* "Your invite is valid until December X, 2023" in "YOU'RE INVITED TO PLUS" footer */
+	/* TODO(remove?) ???? "Your invite is valid until December X, 2023" in "YOU'RE INVITED TO PLUS" footer */
 	.text-gizmo-gray-500 {
 		text-align: center;
 		margin-top: 1rem;
@@ -546,6 +548,8 @@
 		}
 
 	}
+
+	&:has(> [data-comment-id]) {}
 
 }
 

--- a/src/sass/elements/_dialogs.scss
+++ b/src/sass/elements/_dialogs.scss
@@ -560,6 +560,17 @@ html.dark[data-gptheme='oled'] [role='dialog'] {
 	}
 }
 
+
+/* popover with autoplay video showed once when used Canvas for the first time. Probably could be removed after some time in future, "Got it" btn
+"Refine and debug on the spot"
+"Refactor code. Translate to Python. Check for bugs. ChatGPT can do it all, right on the canvas."
+*/
+.popover.fixed.max-w-sm:has(video) {
+	.bg-token-main-surface-secondary.text-token-text-secondary:has(>video) ~ .flex.px-10.py-8 {
+		background-color: var(--c-surface-2) !important;
+	}
+}
+
 /* ! NOT WORKING - CANNOT OVERWRITE THIS WTF */
 /* .dark .popover,
 .light .popover,

--- a/src/sass/elements/_dialogs.scss
+++ b/src/sass/elements/_dialogs.scss
@@ -1,7 +1,7 @@
 /* ===================== DIAOGS ====================  
 not(> [data-comment-id]) - dialog without code comment like in "Run" python code console ("Fix bug")
 */
-[role='dialog']:not([data-comment-id]) {
+[role='dialog']:not(:has(>[data-comment-id])) {
 	padding: var(--p-dialog) !important;
 	background-color: var(--c-bg-dialog) !important;
 	border-radius: var(--br-dialog) !important;

--- a/src/sass/elements/_menu.scss
+++ b/src/sass/elements/_menu.scss
@@ -102,6 +102,8 @@
 	--main-surface-primary: var(--c-surface-2) !important;
 	--main-surface-secondary: var(--c-surface-2) !important;
 	--main-surface-tertiary: var(--c-surface-3) !important;
+	--sidebar-surface-primary: var(--c-surface-2) !important;
+
 	// --main-surface-primary: var(--white) !important;
 	// --main-surface-secondary: var(--gray-100) !important;
 	// --main-surface-tertiary: var(--gray-200) !important;

--- a/src/sass/elements/_right--main.scss
+++ b/src/sass/elements/_right--main.scss
@@ -257,7 +257,10 @@ main [role='presentation'] {
 	}
 
 	/* @ RIGHT - CHATS BUBBLES - GPT */
-	&:has([data-message-author-role='assistant']) {
+	// &:has([data-message-author-role='assistant']) {
+	// ! I HAVE TO CHANGE THE ASSISTENT SELECTOR to ".agent-turn" BCS IT DOESNT EXIST AT SOME SCENARIOS (e.g. when there is canvas only ([id^="textdoc-message"]), without markdown too, when the user stop py Code canvas editing, etc...
+	&:has(.agent-turn) {
+		// border: 2px solid red !important;
 
 		/* ! Without this there was strange issue with User's chat overlaping the menu for "GPT-4" or "GPT-3.5" to choose model in gpt's chat bubble' footer - ONLY FOR MOBILE which is even more strange!!! 
 		Ako neogranicimo ovo samo za mobile, na desktopu ce GPT chat da ide preko sticky headera!! Dok je u mobile ok valjda */
@@ -268,9 +271,10 @@ main [role='presentation'] {
 		}
 
 		/*   RIGHT - CHATS BUBBLE BG 
-		- Adding .markdown here fix flash background of user chat bubble on first message */
-		// & > div.text-base > div[class*="xl:max-w-[48rem]"] {
-		& > div.text-base > div:first-child:has(.markdown) {
+		& > div.text-base > div[class*="xl:max-w-[48rem]"] { // ovo ne moze jer za mobile nema ove klase vec samo md:max-w-3xl
+		& > div.text-base > div[class*="md:max-w-3xl"] {
+		// ? Adding .markdown here fix flash background of user chat bubble on first message */
+		& > div.text-base > div:first-child:has(.markdown, [id^="textdoc-message"]) {
 
 			--pt-multiplier: 1.3;
 			background-color: var(--c-bg-msg-gpt);
@@ -538,45 +542,3 @@ body > .fixed.top-8.right-4 {
 		border-color: var(--c-accent) !important;
 	}
 }
-
-
-// @container article (max-width: $sm) {
-
-// 	[data-testid^='conversation-turn-'] {
-
-// 		& > div {
-// 			--px-chat-bubble-edge-gap: 0.4rem !important;
-// 		}
-
-// 		.mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"] {
-// 			--p-chat-bubble: 0.5rem !important;
-// 			--br-chat-bubble: var(--br) !important;
-// 			// background-color: red !important;
-// 			// border: 4px solid orange !important;
-// 			width: 100% !important;
-
-// 			.flex-shrink-0.flex.flex-col.items-end:has(.gizmo-bot-avatar, .gizmo-shadow-stroke) {
-// 				// background-color: red !important;
-// 				display: none !important;
-// 			}
-
-// 		}
-
-// 		&:has([data-message-author-role='user']) [class*='bg-token-message-surface'] {
-// 			width: 100% !important;
-// 			max-width: 100% !important;
-// 		}
-
-// 		&:has([data-message-author-role='assistent']) {
-// 			border: 2px solid red !important;
-// 		}
-
-// 	}
-
-// 	[data-testid^="conversation-turn-"]:has([data-message-author-role="assistant"]) > div.text-base > div:first-child:has(.markdown) .agent-turn.relative.flex.w-full.flex-col {
-// 		width: 100% !important;
-// 		border: 2px solid red !important;
-
-// 	}
-
-// }

--- a/src/sass/elements/_right--main.scss
+++ b/src/sass/elements/_right--main.scss
@@ -57,6 +57,35 @@ main [role='presentation'] {
 		font-size: calc((var(--fontSize) / 16) * 1rem) !important;
 	}
 
+	/* _________ CANVAS in chat bubbles */
+	&:has([id^="textdoc-message"]) {
+		.popover {
+			--main-surface-primary: var(--c-bg-cm) !important;
+		}
+
+		[id^="textdoc-message"] {
+			--main-surface-primary: var(--c-bg-cm) !important;
+			will-change: border-color;
+			border: 2px solid hsla(var(--accent-hsl) / .12) !important;
+			transition: border-color .2s;
+
+			/* Gradient on the bottom of code */
+			.absolute.bottom-0.z-20.h-24.w-full.transition-colors {
+				background: linear-gradient(rgba(0, 0, 0, 0), var(--c-bg-cm)) !important;
+			}
+		}
+
+		&:hover {
+			border-color: hsla(var(--accent-hsl) / .3) !important;
+		}
+
+
+		/* Chat bubble - "Typing" btn when canvas creating */
+		[role="button"].absolute.bottom-3:has(>.loading-shimmer-pure-text) {
+			// --main-surface-primary: red !important;
+		}
+	}
+
 	/* Right chat content parent
 	.mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"] is GPT chat bubble */
 	// [class*='xl:max-w-[48rem]'], 

--- a/src/sass/elements/_right--main.scss
+++ b/src/sass/elements/_right--main.scss
@@ -2,7 +2,7 @@
 /* .grow.overflow-auto.bg-token-main-surface-primary:has(article) - is for the targeting "Share Link" page */
 .grow.overflow-auto.bg-token-main-surface-primary:has([data-testid^='conversation-turn-']),
 main [role='presentation'] {
-	container: inline-size;
+	container: main / inline-size;
 
 	/* Main Page chat-container  Bg*/
 	&,
@@ -35,9 +35,6 @@ main [role='presentation'] {
 
 /* @ === RIGHT - CHATS BUBBLES ===*/
 [data-testid^='conversation-turn-'] {
-	// container: inline-size / article;
-	// container: inline-size;
-	// container: article / inline-size;
 	/* Edit icon in user chat for example. Edit state user chat bg  */
 	--main-surface-tertiary: var(--c-surface-3) !important;
 	// margin-bottom: var(--mb-chat-bubble) !important;

--- a/src/sass/elements/_right--main.scss
+++ b/src/sass/elements/_right--main.scss
@@ -2,6 +2,7 @@
 /* .grow.overflow-auto.bg-token-main-surface-primary:has(article) - is for the targeting "Share Link" page */
 .grow.overflow-auto.bg-token-main-surface-primary:has([data-testid^='conversation-turn-']),
 main [role='presentation'] {
+	container: inline-size;
 
 	/* Main Page chat-container  Bg*/
 	&,
@@ -34,9 +35,24 @@ main [role='presentation'] {
 
 /* @ === RIGHT - CHATS BUBBLES ===*/
 [data-testid^='conversation-turn-'] {
+	// container: inline-size / article;
+	// container: inline-size;
+	// container: article / inline-size;
 	/* Edit icon in user chat for example. Edit state user chat bg  */
 	--main-surface-tertiary: var(--c-surface-3) !important;
 	// margin-bottom: var(--mb-chat-bubble) !important;
+
+	@include container('sm') {
+		// --px-chat-bubble-edge-gap: 0.45rem;
+		--p-chat-bubble: 1rem;
+		--br-chat-bubble: calc(var(--br) * 1.2);
+
+		.m-auto.text-base:has(>.mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"]) {
+			// border: 2px solid red !important;
+			padding-left: 0.8rem !important;
+			padding-right: 0.8rem !important;
+		}
+	}
 
 	div[data-message-author-role],
 	.prose {
@@ -44,12 +60,18 @@ main [role='presentation'] {
 		font-size: calc((var(--fontSize) / 16) * 1rem) !important;
 	}
 
-	/* TODO: check if this [class*='xl:max-w-[48rem]'] can be removed 
+	/* Right chat content parent
 	.mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"] is GPT chat bubble */
 	// [class*='xl:max-w-[48rem]'], 
 	/* Necu da stavim direkt na chat bubble jer nece biti dobro kad imamo double response prikazan */
+	// .mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"] {
 	.mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"] {
 		max-width: var(--w_chat_gpt) !important;
+
+		@include container('md') {
+			--w_chat_gpt: 100%;
+			width: var(--w_chat_gpt);
+		}
 	}
 
 	/*  Chat bubble footer SVG icons - edit, read aloud, copy, regenerate, bad response */
@@ -229,10 +251,13 @@ main [role='presentation'] {
 			padding: calc(var(--p-chat-bubble) * var(--pt-multiplier)) var(--p-chat-bubble) var(--p-chat-bubble) var(--p-chat-bubble) !important;
 			border-radius: var(--br-chat-bubble) !important;
 
+			@include container('sm') {
+				--pt-multiplier: 1;
+			}
+
 			@include dev('sm') {
 				--pt-multiplier: 1.4;
 			}
-
 
 			/* Left chat content parent 
 		! Adding fixed width prevent content overflowing on the right side of chat bubble when there is some markdown (<pre>) element shown with scrolling horizontally */
@@ -254,9 +279,16 @@ main [role='presentation'] {
 
 				width: calc(100% - var(--svg-w) - var(--svg-gap) - var(--p-chat-bubble) - var(--p-chat-bubble)) !important; // more consistent width (right chat bubble spacing = left spacing)
 
+				@include container('md') {
+					--svg-gap: 1.25rem;
+				}
+
+				@include container('sm') {
+					width: 100% !important;
+				}
 
 				@include dev('md') {
-					--svg-gap: 1.25rem !important; // md-gap-5 (1.25rem)
+					--svg-gap: 1.25rem; // md-gap-5 (1.25rem)
 				}
 
 				@include dev('sm') {
@@ -290,9 +322,14 @@ main [role='presentation'] {
 		}
 
 		/* GPT avatar in its chat bubbles: with img is the GPTs Store item avatar (.gizmo-shadow-stroke), and with svg is gpt logo (.gizmo-bot-avatar	) */
+		@include container('sm') {
+			.flex-shrink-0.flex.flex-col.items-end:has(.gizmo-bot-avatar, .gizmo-shadow-stroke) {
+				display: none !important;
+			}
+		}
+
 		@include dev('sm') {
 			.flex-shrink-0.flex.flex-col.items-end:has(.gizmo-bot-avatar, .gizmo-shadow-stroke) {
-				// background-color: red !important;
 				display: none !important;
 			}
 		}
@@ -475,3 +512,45 @@ body > .fixed.top-8.right-4 {
 		border-color: var(--c-accent) !important;
 	}
 }
+
+
+// @container article (max-width: $sm) {
+
+// 	[data-testid^='conversation-turn-'] {
+
+// 		& > div {
+// 			--px-chat-bubble-edge-gap: 0.4rem !important;
+// 		}
+
+// 		.mx-auto.flex.flex-1.text-base[class*="md:max-w-3xl"] {
+// 			--p-chat-bubble: 0.5rem !important;
+// 			--br-chat-bubble: var(--br) !important;
+// 			// background-color: red !important;
+// 			// border: 4px solid orange !important;
+// 			width: 100% !important;
+
+// 			.flex-shrink-0.flex.flex-col.items-end:has(.gizmo-bot-avatar, .gizmo-shadow-stroke) {
+// 				// background-color: red !important;
+// 				display: none !important;
+// 			}
+
+// 		}
+
+// 		&:has([data-message-author-role='user']) [class*='bg-token-message-surface'] {
+// 			width: 100% !important;
+// 			max-width: 100% !important;
+// 		}
+
+// 		&:has([data-message-author-role='assistent']) {
+// 			border: 2px solid red !important;
+// 		}
+
+// 	}
+
+// 	[data-testid^="conversation-turn-"]:has([data-message-author-role="assistant"]) > div.text-base > div:first-child:has(.markdown) .agent-turn.relative.flex.w-full.flex-col {
+// 		width: 100% !important;
+// 		border: 2px solid red !important;
+
+// 	}
+
+// }

--- a/src/sass/elements/_right--sticky.scss
+++ b/src/sass/elements/_right--sticky.scss
@@ -6,11 +6,12 @@ But adding this "main" blocked this style to smaller screens so I have to add it
  - .sticky.border-token-border-medium je za small devices
  - .sticky.bg-token-main-surface-primary je za small devices
  - not(th) means to not include style on table headings in dialogs
- - not(div[class*="var(--screen-thread-header-min-height"]) means to not include sticky headers in search link sources dialog when clicked on "SOURCES" in chat bubbles */
+ - not(div[class*="var(--screen-thread-header-min-height"]) means to not include sticky headers in search link sources dialog when clicked on "SOURCES" in chat bubbles 
+ - not(.font-mono) je "Run" sticky header u python consoli u Code Canvasu */
 .sticky {
 
 	&.h-header-height,
-	&.bg-token-main-surface-primary:not(th, div[class*="var(--screen-thread-header-min-height"]) {
+	&.bg-token-main-surface-primary:not(th, div[class*="var(--screen-thread-header-min-height"], .font-mono) {
 		// .h-full.overflow-y-auto:has(.sticky [href^='/auth/login?next=/gpts']) .sticky {
 		background: var(--c-bg-chats-sticky) !important;
 		backdrop-filter: blur(var(--blur-sticky));

--- a/src/sass/elements/_right--textarea.scss
+++ b/src/sass/elements/_right--textarea.scss
@@ -79,19 +79,29 @@ main form {
 			}
 		}
 
-		div:has(> input[type='file']) {
+		/* "Attach files" and "Use a tool" buttons, and all others that have that class */
+		span > button.h-8.rounded-lg[aria-label]:has(svg) {
+			background-color: hsla(var(--accent-hsl) / 0.15) !important;
 
-			/* 📎 "Attach files" svg */
-			button:has(> svg) {
-				background-color: hsla(var(--accent-hsl) / 0.15) !important;
-
-				// margin-bottom: calc(var(--p-prompt-textarea) / 2);
-
-				svg {
-					color: var(--c-accent) !important;
-				}
+			svg {
+				color: var(--c-accent) !important;
 			}
 		}
+
+
+		// div:has(> input[type='file']) {
+
+		// 	/* 📎 "Attach files" svg */
+		// 	button:has(> svg) {
+		// 		background-color: hsla(var(--accent-hsl) / 0.15) !important;
+
+		// 		// margin-bottom: calc(var(--p-prompt-textarea) / 2);
+
+		// 		svg {
+		// 			color: var(--c-accent) !important;
+		// 		}
+		// 	}
+		// }
 
 		/* 🖼️ "Attach Files" - attached image wrapper */
 		div[type='button'][aria-haspopup='dialog'] {

--- a/src/sass/elements/_right--textarea.scss
+++ b/src/sass/elements/_right--textarea.scss
@@ -79,13 +79,21 @@ main form {
 			}
 		}
 
-		/* "Attach files" and "Use a tool" buttons, and all others that have that class */
+		/* "Attach files", "Use a tool", "Open in canvas" buttons, and all others that have that class */
 		span > button.h-8.rounded-lg[aria-label]:has(svg) {
-			background-color: hsla(var(--accent-hsl) / 0.15) !important;
+			background-color: transparent;
 
 			svg {
 				color: var(--c-accent) !important;
 			}
+
+			&:hover {
+				background-color: hsla(var(--accent-hsl) / 0.13) !important;
+			}
+		}
+
+		span > button[aria-label="Open in canvas"]:has(svg) {
+			background-color: hsla(var(--accent-hsl) / 0.13) !important;
 		}
 
 

--- a/src/sass/global/_colors-bgs.scss
+++ b/src/sass/global/_colors-bgs.scss
@@ -168,13 +168,22 @@ This content may violate our Terms of Use or usage policies. is bg-orange-400 no
 - Prompt textarea send button
 - GPTs - active pill ("Top Picks")
  */
-// .bg-black,
-[class*='bg-black'],
+.bg-black,
+// [class*='bg-black'],// @@@@@ THIS MAKES CHATS NOT VISIBLE IN FIREFOX ON LIGHT THEME
 .bg-token-sidebar-surface-primary {
 	background-color: var(--c-surface-1);
+	// background-color: orange;
 	// @include borderBoxShadow(lightgreen);
 	// background-color: lightgreen;
 }
+
+/* @@@@@ DEBUG FIREFOX -  THIS MAKES CHATS NOT VISIBLE IN FIREFOX ON LIGHT THEME */
+/* [class*='bg-black'] {
+	outline: 2px solid red !important;
+	border: 2px solid red !important;
+	background: red !important;
+	box-shadow: 0 0 0 4px red !important;
+} */
 
 /* 
 - Builder profile "PlaceholderGPT" - var(--c-surface-3)

--- a/src/sass/global/_colors-bgs.scss
+++ b/src/sass/global/_colors-bgs.scss
@@ -145,8 +145,10 @@ This content may violate our Terms of Use or usage policies. is bg-orange-400 no
 - Checkbox circle
 - GPTs Store PAGE - Search query section
 - GPTs Store PAGE - Search query section link-on-hover - CHANGE IT !!
+
+- .streaming-line-overlay are lines during the processing edit in Code Canvas (like add logs etc)
  */
-[class*='bg-white'],
+[class*='bg-white']:not(.streaming-line-overlay),
 .bg-token-sidebar-surface-secondary {
 	background-color: var(--c-surface-2) !important;
 	// @include borderBoxShadow(red);

--- a/src/sass/global/_colors-bgs.scss
+++ b/src/sass/global/_colors-bgs.scss
@@ -148,7 +148,7 @@ This content may violate our Terms of Use or usage policies. is bg-orange-400 no
 
 - .streaming-line-overlay are lines during the processing edit in Code Canvas (like add logs etc)
  */
-[class*='bg-white']:not(.streaming-line-overlay),
+[class*='bg-white']:not(.streaming-line-overlay, [role="combobox"]),
 .bg-token-sidebar-surface-secondary {
 	background-color: var(--c-surface-2) !important;
 	// @include borderBoxShadow(red);

--- a/src/sass/global/_colors-txts.scss
+++ b/src/sass/global/_colors-txts.scss
@@ -7,7 +7,7 @@
 	- [class*='text-gray-'] utice i na div[data-radix-popper-content-wrapper] tj "Theme" dropdown iteme te ne mogu da se overwrituju tamo u _menu.scss. Zato sam sklonila !important
 */
 [class*='text-gray-']:not(.text-gray-100, .text-gray-400, .text-gray-500, .text-gray-600),
-[class*='text-white']:not(.btn-primary .text-white, .bg-green-600, svg, .toast-root .text-white[role='alert']) {
+[class*='text-white']:not(.btn-primary .text-white, .bg-green-600, svg, .toast-root .text-white[role='alert'], [data-testid="composer-speech-button"]) {
 	color: var(--c-txt);
 }
 

--- a/src/sass/gpthemes/_gpth-floating-btn.scss
+++ b/src/sass/gpthemes/_gpth-floating-btn.scss
@@ -8,7 +8,6 @@
 		position: fixed;
 		top: var(--top);
 		right: var(--right);
-		// z-index: 1;
 		transform: scale(var(--floating-scale)) rotate(var(--floating-rotate));
 		transition: transform 0.8s $easeInOutCirc;
 

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -36,6 +36,7 @@
 @import 'elements/_modal';
 @import 'elements/_dialogs';
 @import 'elements/_right--main';
+@import 'elements/_canvas';
 @import 'elements/_right--new-chat';
 @import 'elements/_right--sticky';
 @import 'elements/_right--textarea';


### PR DESCRIPTION
Closes #86, #88, #89, #91, #92, #93 

There's more work to do. See #86, #89, #91, #92, #93, #94

> [!IMPORTANT]
> The `CodeMirror`  editor in the canvas feature fails to properly update its syntax highlighting when themes are changed using the GPThemes floating button. While the overall UI theme changes, the code highlighting remains in the previous theme's style, creating a visual inconsistency.
> However, changing the theme via the ChatGPT settings correctly updates the `CodeMirror` syntax highlighting.