### PR TITLE
[65] Fix theme button disappears after page re-renders (init fails on Remix hydration)

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -14,17 +14,24 @@ const CONFIG = {
 
 // Track number of attempts
 let retryCount = 0
+let retryTimeout = null // For cleanup
 
 // Main initialization function
 function initExtension() {
-	console.log(`[🎨GPThemes]: Initializing components (attempt ${retryCount + 1})`)
+	console.log(`[🎨GPThemes]: Initializing components (attempt ${retryCount + 1}/${CONFIG.MAX_RETRIES})`)
 
-	initThemes()
-	initFloating()
-	initColors()
-	initFonts()
-	initWidths()
-	initScrolldown()
+	try {
+		initThemes()
+		initFloating()
+		initColors()
+		initFonts()
+		initWidths()
+		initScrolldown()
+	} catch (error) {
+		console.error('[🎨GPThemes]: Critical initialization error:', error)
+		return false
+	}
+	return true
 }
 
 // Schedule retries with exponential backoff
@@ -36,30 +43,46 @@ function scheduleRetry() {
 
 		console.log(`[🎨GPThemes]: Scheduling retry ${retryCount}/${CONFIG.MAX_RETRIES} in ${delay}ms`)
 
-		setTimeout(() => {
+		retryTimeout = setTimeout(() => {
 			// Check if our components exist before retrying
 			if (document.querySelector(CONFIG.TARGET_SELECTOR)) {
-				console.log('[🎨GPThemes]: Components already present, no need to retry')
+				console.log('[🎨GPThemes]: Components already present, stopping retries')
+				cleanup()
 				return
 			}
 
 			console.info(
-				'[🎨GPThemes]: Re-initializing extension because there is probably "Minified React error #" above this...'
+				'[🎨GPThemes]: Re-initializing extension (possible React hydration issue: "Minified React error #XXX;" above?)'
 			)
 
-			// Retry initialization
-			initExtension()
-
-			// Schedule next retry if needed
-			scheduleRetry()
+			if (initExtension()) {
+				console.log('[🎨GPThemes]: Injection successful')
+				cleanup()
+			} else {
+				scheduleRetry()
+			}
 		}, delay)
 	} else {
 		console.log('[🎨GPThemes]: Maximum retries reached')
 	}
 }
 
-// Initial run
-initExtension()
+// Cleanup function
+function cleanup() {
+	if (retryTimeout) {
+		clearTimeout(retryTimeout)
+		retryTimeout = null
+	}
+}
 
-// Start retry sequence
-scheduleRetry()
+// Initial run
+if (!document.querySelector(CONFIG.TARGET_SELECTOR)) {
+	initExtension()
+	scheduleRetry()
+} else {
+	console.log('[🎨GPThemes]: Components already present on first check')
+}
+
+// Emergency cleanup if script re-runs
+if (window._gpthCleanup) window._gpthCleanup()
+window._gpthCleanup = cleanup

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -5,9 +5,61 @@ import { init as initFonts } from './app/mainFonts'
 import { init as initWidths } from './app/mainWidths'
 import { init as initScrolldown } from './app/scrolldown'
 
-initThemes()
-initFloating()
-initColors()
-initFonts()
-initWidths()
-initScrolldown()
+// Configuration
+const CONFIG = {
+	TARGET_SELECTOR: '.gpth-settings',
+	RETRY_DELAY: 2000,
+	MAX_RETRIES: 4,
+}
+
+// Track number of attempts
+let retryCount = 0
+
+// Main initialization function
+function initExtension() {
+	console.log(`[🎨GPThemes]: Initializing components (attempt ${retryCount + 1})`)
+
+	initThemes()
+	initFloating()
+	initColors()
+	initFonts()
+	initWidths()
+	initScrolldown()
+}
+
+// Schedule retries with exponential backoff
+function scheduleRetry() {
+	retryCount++
+
+	if (retryCount <= CONFIG.MAX_RETRIES) {
+		const delay = CONFIG.RETRY_DELAY * retryCount
+
+		console.log(`[🎨GPThemes]: Scheduling retry ${retryCount}/${CONFIG.MAX_RETRIES} in ${delay}ms`)
+
+		setTimeout(() => {
+			// Check if our components exist before retrying
+			if (document.querySelector(CONFIG.TARGET_SELECTOR)) {
+				console.log('[🎨GPThemes]: Components already present, no need to retry')
+				return
+			}
+
+			console.info(
+				'[🎨GPThemes]: Re-initializing extension because there is probably "Minified React error #" above this...'
+			)
+
+			// Retry initialization
+			initExtension()
+
+			// Schedule next retry if needed
+			scheduleRetry()
+		}, delay)
+	} else {
+		console.log('[🎨GPThemes]: Maximum retries reached')
+	}
+}
+
+// Initial run
+initExtension()
+
+// Start retry sequence
+scheduleRetry()


### PR DESCRIPTION
Re-initialize GPThemes components after DOM resets (`Minified React error #418;`)

### Repro:  
1. Load page - button appears  
2. A second, two after - button vanishes  
3. See `Minified React error #` in console  

### Expected:  
Button and extension funcionallity should persist through re-renders 

Closes #65 