### PR TITLE
[156] Restore user chat bubble features after OpenAI DOM updates

### DIFF
--- a/src/sass/customs/_custom--chats.scss
+++ b/src/sass/customs/_custom--chats.scss
@@ -22,7 +22,7 @@
 
         /* New selector: 2025-04-10 */
         // .bg-token-message-surface[class*="max-w-[var(--user-chat-width,70%)]"] {
-        .bg-token-message-surface {
+        .user-message-bubble-color {
             // width: var(--max_w_chat_user) !important;
             // max-width: var(--w_chat_user) !important;
             width: var(--w_chat_user, auto) !important;

--- a/src/sass/elements/_right--main.scss
+++ b/src/sass/elements/_right--main.scss
@@ -123,7 +123,7 @@
 
 		/* RIGHT - CHATS BUBBLE BG */
 		/*NEW SELECTOR: 2025-04-10 - User message - max-w-[var(--user-chat-width,70%)] */
-		.bg-token-message-surface {
+		.user-message-bubble-color {
 			background-color: var(--toggleBgUser);
 			padding: var(--p-chat-bubble) calc(var(--p-chat-bubble) * var(--p-chat-bubble-multiply));
 			// padding: var(--p-chat-bubble) !important;


### PR DESCRIPTION
Closes #156 

- [x] Fix user chat bubble backgrounds not displaying correctly due to recent OpenAI DOM changes
- [x] Restore toggle functionality for USER chat bubbles that was broken by the updates
- [x] Address incorrect user bubble widths when the full-width chats feature is enabled
- [x] Update selectors and logic to align with the latest OpenAI DOM structure