### PR TITLE
Prevent color clipping by clamping OKLCH channels

### DIFF
--- a/src/sass/abstract/_vars-gpth-colors.scss
+++ b/src/sass/abstract/_vars-gpth-colors.scss
@@ -12,9 +12,6 @@ $alphas: (
 );
 
 :root {
-
-    // contain: layout style paint;
-
     --c-default-accent-light: #4d4d34; // #6c4756; // #695a4a // #564c37 // #564c37 // #41370b
     --c-default-accent-dark: #c2d8c4; // #bfa8ff;
     // --c-default-accent-light: #f98be9; // za swatch: #425100 (dark green), #777744 (light green)
@@ -38,7 +35,7 @@ $alphas: (
     --c-scrollbar-thumb: var(--c-surface-3);
     --c-scrollbar-track: transparent;
 
-    --c-bg-sidebar: oklch(from var(--c-surface-2) calc(l * 1.0165) c h);
+    --c-bg-sidebar: oklch(from var(--c-surface-2) clamp(0, calc(l * 1.0165), 1) c h);
     --c-bg-sidebar-link: var(--c-surface-3);
     // --c-bg-sibebar-link: oklch(from var(--c-bg-sidebar) calc(l * 0.96) c h);
     --c-bg-cm: var(--c-surface-1);
@@ -70,8 +67,8 @@ html.light {
     --c-accent-light: color-mix(in oklch, var(--c-surface-1), var(--c-accent) 14%);
 
     --c-surface-1: oklch(from var(--user-surface-1, var(--c-accent)) 0.95 0.005 h);
-    --c-surface-2: oklch(from var(--user-surface-2, var(--c-surface-1)) calc(l * 0.98) calc(c * 1.12) h);
-    --c-surface-3: oklch(from var(--user-surface-3, var(--c-surface-2)) calc(l * 0.98) calc(c * 1.22) h);
+    --c-surface-2: oklch(from var(--user-surface-2, var(--c-surface-1)) clamp(0, calc(l * 0.98), 1) clamp(0, calc(c * 1.12), 0.4) h);
+    --c-surface-3: oklch(from var(--user-surface-3, var(--c-surface-2)) clamp(0, calc(l * 0.98), 1) clamp(0, calc(c * 1.22), 0.4) h);
 
     --c-txt: oklch(from var(--user-text-1, var(--c-accent)) 0 c h);
     --c-subtext-1: oklch(from var(--user-text-2, var(--c-accent)) 0.3 c h);
@@ -87,12 +84,12 @@ html.light {
     --c-bg-msg-user: var(--c-accent-12);
     // --c-bg-msg-gpt: oklch(from var(--c-surface-1) calc(l * 0.98) c h);
     // --c-bg-msg-gpt: oklch(from var(--c-surface-1) calc(l * 0.978) calc(c * 1.15) h);
-    --c-bg-msg-gpt: oklch(from var(--c-surface-1) calc(l * 0.98) calc(c * 1.1) h);
+    --c-bg-msg-gpt: oklch(from var(--c-surface-1) clamp(0, calc(l * 0.98), 1) clamp(0, calc(c * 1.1), 0.4) h);
     // --c-bg-msg-gpt: oklch(from var(--c-surface-1) calc(l * 0.975) calc(c * 1.2) h);
     // --c-bg-msg-gpt: oklch(from var(--c-surface-1) calc(l * 0.975) c h);
 
     // --c-bg-chats-container: oklch(from var(--c-surface-1) calc(l * 1.0315) calc(c * 0.97) h);
-    --c-bg-chats-container: oklch(from var(--c-surface-1) calc(l * 1.0189) c h);
+    --c-bg-chats-container: oklch(from var(--c-surface-1) clamp(0, calc(l * 1.0189), 1) c h);
 
     --c-bg-modal: oklch(from var(--c-accent) 0.2 calc(c * 0.75) h / 0.3);
     // --c-bg-menu: oklch(from var(--c-accent) l calc(c * 0.35) h / 0.5);
@@ -119,12 +116,12 @@ html.dark {
     --c-on-accent: oklch(from var(--c-accent) 0.25 c h);
     --c-accent-light: oklch(from var(--c-accent) 0.35 calc(c * 0.4) h);
 
-    --c-surface-1: oklch(from var(--user-surface-1, var(--c-accent)) 0.24 calc(c * 0.18) h);
-    --c-surface-2: oklch(from var(--user-surface-2, var(--c-surface-1)) calc(l * 1.256) calc(c * 1.4) h);
-    --c-surface-3: oklch(from var(--user-surface-3, var(--c-surface-2)) calc(l * 1.2) calc(c * 1.4) h);
+    --c-surface-1: oklch(from var(--user-surface-1, var(--c-accent)) 0.245 calc(c * 0.189) h);
+    --c-surface-2: oklch(from var(--user-surface-2, var(--c-surface-1)) clamp(0, calc(l * 1.256), 1) clamp(0, calc(c * 1.4), 0.4) h);
+    --c-surface-3: oklch(from var(--user-surface-3, var(--c-surface-2)) clamp(0, calc(l * 1.2), 1) clamp(0, calc(c * 1.4), 0.4) h);
 
-    --c-bg-chats-container: oklch(from var(--c-surface-1) calc(l * 1.03) calc(c * 1.05) h);
-    --c-bg-msg-gpt: oklch(from var(--c-bg-chats-container) calc(l * 1.15) calc(c * 1.3) h);
+    --c-bg-chats-container: oklch(from var(--c-surface-1) clamp(0, calc(l * 1.014), 1) clamp(0, calc(c * 1.038), 0.4) h);
+    --c-bg-msg-gpt: oklch(from var(--c-bg-chats-container) clamp(0, calc(l * 1.15), 1) clamp(0, calc(c * 1.3), 0.4) h);
     // --c-bg-msg-gpt: oklch(from var(--c-accent) 0.35 calc(c * 0.282) h);
 
     // --c-surface-1: oklch(from var(--user-surface-1, var(--c-accent)) 0.26 calc(c * 0.2) h);
@@ -159,7 +156,7 @@ html.dark {
     // --c-bg-modal: oklch(from var(--c-accent) 0.92 calc(c * 0.65) h / 0.25);
     // --c-bg-dialog: var(--c-surface-2);
     // --c-bg-menu: oklch(from var(--c-surface-2) 0.4 calc(c * 0.6) h / 0.3);
-    --c-bg-menu: oklch(from var(--c-surface-2) 0.35 calc(c * 1.4) h / 0.3);
+    --c-bg-menu: oklch(from var(--c-surface-2) 0.35 clamp(0, calc(c * 1.4), 0.4) h / 0.3);
     --brightness-menu: brightness(1);
 
     --c-bg-sidebar: var(--c-surface-1);
@@ -176,7 +173,7 @@ html.dark[data-gptheme='oled'] {
     --c-surface-1: oklch(0 0 0); // darkest
     // --c-surface-2: oklch(from var(--user-surface-2, var(--c-accent)) 0.23 calc(c * 0.25) h);
     --c-surface-2: oklch(from var(--user-surface-2, var(--c-accent)) 0.23 calc(c * 0.18) h);
-    --c-surface-3: oklch(from var(--user-surface-3, var(--c-surface-2)) calc(l * 1.2) calc(c * 1.2) h);
+    --c-surface-3: oklch(from var(--user-surface-3, var(--c-surface-2)) clamp(0, calc(l * 1.2), 1) clamp(0, calc(c * 1.2), 0.4) h);
 
     --c-bg-chats-container: var(--c-surface-1);
     // --c-bg-msg-gpt: hsl(var(--accent-h), calc(var(--surface-s) + 20%), calc(var(--surface-l) + 6%));

--- a/src/sass/elements/_images-layout.scss
+++ b/src/sass/elements/_images-layout.scss
@@ -6,7 +6,7 @@ body>.pointer-events-none.fixed.inset-0.contain-size[data-shader] {
 	// background: radial-gradient(circle at 60% 50%, var(--c-accent-10), var(--c-bg-sidebar), var(--c-bg-sidebar));
 	// background: radial-gradient(farthest-corner at 55% 70%, var(--c-accent-10), transparent, var(--c-bg-sidebar));
 	// background: radial-gradient(farthest-corner at 55% 70%, var(--c-accent-10), transparent, var(--c-bg-sidebar), var(--c-bg-sidebar));
-	background: radial-gradient(farthest-corner at 55% 80%, var(--c-accent-10), var(--c-accent-03), var(--c-bg-sidebar), var(--c-bg-sidebar));
+	background: radial-gradient(farthest-corner at 55% 80%, var(--c-accent-12), var(--c-accent-03), var(--c-bg-sidebar), var(--c-bg-sidebar));
 	background-blend-mode: difference;
 
 	/* 	background: radial-gradient(circle farthest-side at 15% 75%, var(--c-accent-20) 0%, var(--c-bg-sidebar) 100%),


### PR DESCRIPTION
Wrapped L and C calc functions with clamp(0, ..., 1) and clamp(0, ..., 0.4) to prevent color clipping and ensure gamut safety across different displays.

- [x] Lightness: Clamped calc() results between 0 and 1 to prevent broken black/white rendering
- [x] Chroma: Clamped scaling factors to a max of 0.4 to avoid "neon" clipping and hue shifts on standard (sRGB) displays