### PR TITLE
Fix color picker not opening in Chrome on MacBook Pro (Sequoia 15.1 Beta)

### DIFF
--- a/src/libs/jscolorpicker/colorpicker-my-style-optimized.scss
+++ b/src/libs/jscolorpicker/colorpicker-my-style-optimized.scss
@@ -442,10 +442,10 @@
 
 /* ----- PERFORMANCE BOOST ----- */
 // GPU acceleration for draggable elements only
-.cp_thumb {
-  backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
-}
+// .cp_thumb {
+//   backface-visibility: hidden;
+//   -webkit-backface-visibility: hidden;
+// }
 
 // GPU layers for all interactive elements  
 /* .cp_area-hsv,
@@ -453,3 +453,10 @@
 .cp_slider-alpha {
   transform: translateZ(0);
 } */
+
+/* Potentional fix for MacBook - colorpicker not opening */
+.cp_button,
+.cp_caret,
+.cp_caret svg {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
Related to #181 

- Remove `backface-visibility` as a potential fix for rendering issues affecting the color picker
- Force `pointer-events: none` on child elements of the color picker to address potential pointer event conflicts

> [!NOTE]
> - This is a **speculative fix** due to limited information about the root cause. User testing is needed (@caroline-boop)
> - Request users to test the changes on affected devices (e.g., MacBook Pro Chrome 2024 Sequoia 15.1 Beta) to confirm resolution