### PR TITLE
Add better style support for Codex Cloud (#215)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,3 @@
+{
+	"nodeModulesDir": "none"
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,12 @@
 {
   "version": "5",
-  "remote": {
-    "https://cdn.jsdelivr.net/npm/fflate/esm/browser.js": "8cc1f687e0159e977addb6b85e274dbd11e622cf151f4fcb7b85d49622ea43e7"
+  "specifiers": {
+    "npm:fflate@0.8.2": "0.8.2"
+  },
+  "npm": {
+    "fflate@0.8.2": {
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    }
   },
   "workspace": {
     "packageJson": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,13 +754,9 @@ packages:
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
-  baseline-browser-mapping@2.10.29:
-    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+  baseline-browser-mapping@2.10.42:
+    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  baseline-browser-mapping@2.9.5:
-    resolution: {integrity: sha512-D5vIoztZOq1XM54LUdttJVc96ggEsIfju2JBvht06pSzpckp3C7HReun67Bghzrtdsq9XdMGbSSB3v3GhMNmAA==}
     hasBin: true
 
   braces@3.0.3:
@@ -784,11 +780,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001759:
-    resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
-
-  caniuse-lite@1.0.30001792:
-    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+  caniuse-lite@1.0.30001803:
+    resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2351,7 +2344,7 @@ snapshots:
   autoprefixer@10.5.0(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001792
+      caniuse-lite: 1.0.30001803
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.6
@@ -2363,9 +2356,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  baseline-browser-mapping@2.10.29: {}
-
-  baseline-browser-mapping@2.9.5: {}
+  baseline-browser-mapping@2.10.42: {}
 
   braces@3.0.3:
     dependencies:
@@ -2373,16 +2364,16 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.5
-      caniuse-lite: 1.0.30001759
+      baseline-browser-mapping: 2.10.42
+      caniuse-lite: 1.0.30001803
       electron-to-chromium: 1.5.266
       node-releases: 2.0.27
       update-browserslist-db: 1.2.2(browserslist@4.28.1)
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.29
-      caniuse-lite: 1.0.30001792
+      baseline-browser-mapping: 2.10.42
+      caniuse-lite: 1.0.30001803
       electron-to-chromium: 1.5.353
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
@@ -2397,9 +2388,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001759: {}
-
-  caniuse-lite@1.0.30001792: {}
+  caniuse-lite@1.0.30001803: {}
 
   chalk@4.1.2:
     dependencies:

--- a/scripts/zip.js
+++ b/scripts/zip.js
@@ -1,6 +1,5 @@
-// Using a CDN urlURL for fflate, which is compatible with Deno's ES module import
-// zipSync is used for synchronous, high-perf compression
-import { zipSync } from 'https://cdn.jsdelivr.net/npm/fflate/esm/browser.js'
+// Using a CDN urlURL for fflate, which is compatible with Deno's ES module import. zipSync is used for synchronous, high-perf compression
+import { zipSync } from 'npm:fflate@0.8.2'
 
 const CONFIG = {
 	// Paths to the manifest files to read the extension version from
@@ -45,8 +44,7 @@ async function deleteExistingFile(filePath) {
 	}
 }
 
-// Recursively traverses a folder and collects all files into a map
-// compatible with fflate's zipSync, using relative paths as keys
+// Recursively traverses a folder and collects all files into a map compatible with fflate's zipSync, using relative paths as keys
 async function collectFiles(folderPath, basePath = '') {
 	const files = {}
 

--- a/src/sass/abstract/_vars-gpt.scss
+++ b/src/sass/abstract/_vars-gpt.scss
@@ -44,6 +44,8 @@ html,
     --bg-status-warning: #{color-alpha(--c-warning, 0.2, true)};
     --bg-status-error: #{color-alpha(--c-danger, 0.2, true)};
 
+    --bg-secondary-surface: var(--c-bg-chats-container) !important;
+
     --bg-tooltip: color-mix(var(--c-accent) 10%, var(--c-surface-2)) !important;
     /* .border-token-border-default
 	- border oko "Uprade" btn-a

--- a/src/sass/abstract/_vars-gpt.scss
+++ b/src/sass/abstract/_vars-gpt.scss
@@ -10,6 +10,7 @@ OPENAAI CSS VARS
     --white: var(--c-surface-1) !important;
     // --black: var(--c-accent) !important;
     --black: var(--c-bg-chats-container) !important;
+    --right-bg: var(--c-bg-chats-container) !important;
     // --gray-50: #f9f9f9;
     // --gray-100: #ececec;
     // --gray-200: #e3e3e3;
@@ -149,6 +150,9 @@ html,
     // --interactive-bg-accent-hover: oklch(from var(--c-accent) 0.95 0.08 h) !important;
     --interactive-bg-accent-hover: oklch(from var(--c-accent) 0.9 calc(c * 0.4) h) !important;
     --interactive-bg-accent-press: oklch(from var(--c-accent) 0.77 calc(c * 0.4) h) !important;
+
+    --interactive-bg-tertiary-hover: var(--c-accent-12) !important;
+    --interactive-bg-tertiary-press: var(--c-accent-20) !important;
 
     --interactive-label-accent-default: var(--c-accent) !important;
 

--- a/src/sass/abstract/_vars-gpt.scss
+++ b/src/sass/abstract/_vars-gpt.scss
@@ -54,7 +54,7 @@ html,
     --border-default: var(--c-border) !important;
     --border-light: var(--c-border) !important;
     --border-extra-light: var(--c-border) !important;
-    // --border-heavy: #fff3;
+    --border-heavy: var(--c-border) !important;
     --border-status-warning: #{color-alpha(--c-warning, 0.2, true)};
     --border-status-error: #{color-alpha(--c-danger, 0.2, true)};
     --text-primary: var(--c-txt) !important;

--- a/src/sass/global/_colors-bgs.scss
+++ b/src/sass/global/_colors-bgs.scss
@@ -404,3 +404,7 @@ button.bg-token-interactive-label-accent-default {
 		color: var(--c-on-accent) !important;
 	}
 }
+
+.bg-\[\#22c55e\] {
+	background-color: var(--c-accent) !important;
+}

--- a/src/sass/global/_colors-bgs.scss
+++ b/src/sass/global/_colors-bgs.scss
@@ -412,10 +412,15 @@ button.bg-token-interactive-label-accent-default {
 
 // Codex -> Settings -> Analytics -> Monthly usage limit white line
 .bg-\[\#ebebf0\] {
-	background-color: oklch(from var(--c-accent) 97% c h) !important;
+	background-color: var(--c-accent-light) !important;
 }
 
 .dark\:bg-\[\#1E1E1E\],
 .bg-\[\#1E1E1E\] {
 	background-color: var(--c-bg-chats-container) !important;
+}
+
+// Codex -> https://chatgpt.com/codex/cloud/tasks -> "Logs" element on right
+.\[--right-bg\:var\(--bg-tertiary\)\] {
+	--right-bg: var(--c-bg-chats-container) !important;
 }

--- a/src/sass/global/_colors-bgs.scss
+++ b/src/sass/global/_colors-bgs.scss
@@ -405,6 +405,17 @@ button.bg-token-interactive-label-accent-default {
 	}
 }
 
+// Codex -> Settings -> Analytics -> Monthly usage limit green line
 .bg-\[\#22c55e\] {
 	background-color: var(--c-accent) !important;
+}
+
+// Codex -> Settings -> Analytics -> Monthly usage limit white line
+.bg-\[\#ebebf0\] {
+	background-color: oklch(from var(--c-accent) 97% c h) !important;
+}
+
+.dark\:bg-\[\#1E1E1E\],
+.bg-\[\#1E1E1E\] {
+	background-color: var(--c-bg-chats-container) !important;
 }

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -59,6 +59,7 @@
 @import "elements/_voice-room";
 @import "elements/_images-layout";
 @import "pages/_gpt-store";
+@import "pages/_codex";
 @import "elements/_transitions";
 @import "elements/_search";
 @import "customs/_custom--chats";

--- a/src/sass/pages/_codex.scss
+++ b/src/sass/pages/_codex.scss
@@ -1,0 +1,7 @@
+form #custom-instructions {
+
+    textarea,
+    input {
+        background-color: var(--c-surface-2) !important;
+    }
+}

--- a/src/sass/pages/_codex.scss
+++ b/src/sass/pages/_codex.scss
@@ -1,7 +1,16 @@
-form #custom-instructions {
+form {
 
-    textarea,
-    input {
+    #custom-instructions,
+    #branch-format {
+
+        textarea,
+        input {
+            background-color: var(--c-surface-2) !important;
+        }
+
+    }
+
+    [class*="focus-within:ring-1"] {
         background-color: var(--c-surface-2) !important;
     }
 }


### PR DESCRIPTION
- [x] Fix broken dark theme bg using `--bg-secondary-surface` (mapped to `--c-bg-chats-container`) instead of pure black
- [x] Improve border definition across Codex components
- [x] Align form inputs with the theme system
- [x] Improve table row hover styling
- [x] Fix `Logs` panel background to match chat UI
- [x] Improve `Monthly usage limit` progress bar
- [x] Verify consistency across light, dark, and OLED themes
- [x] Needs more testing/investigation

**Summary:** Visual fix pass for Codex interface, dark theme bg, borders, inputs, table hover, progress bar, and `Logs` panel, restoring consistency with the rest of the extension.

---

## Extension testing

1. Download the artifact: `GPThemes-debug-PR#xyz-xyzxyz`
2. Unzip this downloaded artifact to access the files inside
3. Navigate to Chrome Extensions: `chrome://extensions/`
4. Enable `Developer mode` in the top-right corner
5. ⚠️ **Important: If you already have GPThemes extension installed, please disable it first**
6. Drag and drop the file `gpthemes-chromium-mv3-vX.Y.Z.zip` (found inside the unzipped artifact) onto the extensions page to install
7. Visit ChatGPT and refresh the page to apply the changes
