### PR TITLE
Fix deprecation of Node 20 on GitHub Actions runners

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,20 @@
 ---
 
-## Extension testing
+## Extension Testing Instructions
 
-1. Download the artifact: `GPThemes-debug-PR#xyz-xyzxyz`
-2. Unzip this downloaded artifact to access the files inside
-3. Navigate to Chrome Extensions: `chrome://extensions/`
-4. Enable `Developer mode` in the top-right corner
-5. ⚠️ **Important: If you already have GPThemes extension installed, please disable it first**
-6. Drag and drop the file `gpthemes-chromium-mv3-vX.Y.Z.zip` (found inside the unzipped artifact) onto the extensions page to install
-7. Visit ChatGPT and refresh the page to apply the changes
+1. Download the build artifact:  
+   `GPThemes-debug-PR#xyz-xyzxyz`
+
+2. Unzip the downloaded artifact to access the files inside.
+
+3. Open the Chrome Extensions page:  
+   `chrome://extensions/`
+
+4. Toggle **Developer mode** ON (top-right corner).
+
+5. ⚠️ Before proceeding: If you have GPThemes already installed, disable it first to avoid conflicts.
+
+6. Drag and drop the following file from the extracted folder onto the Extensions page:  
+   `gpthemes-chromium-mv3-vX.Y.Z.zip`
+
+7. Visit [ChatGPT](https://chatgpt.com) and **refresh the page** to apply the changes.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js & pnpm
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '24'
                   cache: 'pnpm'
 
             - name: Install pnpm deps

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Setup Node.js & pnpm
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '24'
                   cache: 'pnpm'
 
             - name: Install pnpm deps


### PR DESCRIPTION
Bump Node version from `20` to `24` for Github Actions
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

---

## Extension testing

1. Download the artifact: `GPThemes-debug-PR#xyz-xyzxyz`
2. Unzip this downloaded artifact to access the files inside
3. Navigate to Chrome Extensions: `chrome://extensions/`
4. Enable `Developer mode` in the top-right corner
5. ⚠️ **Important: If you already have GPThemes extension installed, please disable it first**
6. Drag and drop the file `gpthemes-chromium-mv3-vX.Y.Z.zip` (found inside the unzipped artifact) onto the extensions page to install
7. Visit ChatGPT and refresh the page to apply the changes
