### PR TITLE
Fix `Hide Footer` toggle not working

### DIFF
--- a/src/js/app/config/consts-hidden-els.js
+++ b/src/js/app/config/consts-hidden-els.js
@@ -16,8 +16,8 @@ export const ELEMENTS = [
 	},
 	{
 		id: SELECTORS.HIDE.FOOTER.TOGGLE_ID,
-		label: 'Hide Footer',
-		subtitle: 'Hide info below the message box for a cleaner view',
+		label: 'Hide AI Disclaimer',
+		subtitle: 'Hide info above the chatbox for a cleaner view',
 		icon: icon_footer,
 		selector: SELECTORS.HIDE.FOOTER.SELECTOR,
 		dataAttr: ATTR_HIDE_FOOTER,

--- a/src/js/app/config/selectors.js
+++ b/src/js/app/config/selectors.js
@@ -112,7 +112,7 @@ export const SELECTORS = {
 		FOOTER: {
 			TOGGLE_ID: `${PFX}-hide-footer`,
 			// SELECTOR: `#thread-bottom-container > #thread-bottom ~ div.min-h-8 > div`,
-			SELECTOR: `#main div#thread-bottom-container>div:last-of-type:is(.-mt-4),#main div.sticky.bottom-0 .min-h-8.w-full.text-xs.text-pretty`,
+			SELECTOR: `[data-testid="thread-disclaimer"]`,
 		},
 		UPGRADE: {
 			TOGGLE_ID: `${PFX}-hide-upgrade-chip`,

--- a/src/sass/customs/_custom--hides.scss
+++ b/src/sass/customs/_custom--hides.scss
@@ -34,17 +34,17 @@ html[data-gpth-hide-header] header#page-header {
 /* Footer */
 html[data-gpth-hide-footer] {
 
+    // /* Footer in Group Chats */
+    // #main div.sticky.bottom-0 .min-h-8.w-full.text-xs.text-pretty,
     /* Footer in basic chats */
-    #main div#thread-bottom-container>div:last-of-type:is(.-mt-4),
-    /* Footer in Group Chats */
-    #main div.sticky.bottom-0 .min-h-8.w-full.text-xs.text-pretty {
+    [data-testid="thread-disclaimer"] {
         display: none !important;
     }
 
-    /* Add padding bottom to add gap from window bottom edge (for chatbox in "Group Chats") */
-    #main div.sticky.bottom-0 {
-        padding-bottom: 0.2rem;
-    }
+    // /* Add padding bottom to add gap from window bottom edge (for chatbox in "Group Chats") */
+    // #main div.sticky.bottom-0 {
+    //     padding-bottom: 0.2rem;
+    // }
 }
 
 /* "Upgrade for free" chip button in header and "Claim offer" button in sidebar */


### PR DESCRIPTION
issue #226

---

## Extension Testing Instructions

1. Download the build artifact:  
   `GPThemes-debug-PR#xyz-xyzxyz`

2. Unzip the downloaded artifact to access the files inside.

3. Open the Chrome Extensions page:  
   `chrome://extensions/`

4. Toggle **Developer mode** ON (top-right corner).

5. ⚠️ Before proceeding: If you have GPThemes already installed, disable it first to avoid conflicts.

6. Drag and drop the following file from the extracted folder onto the Extensions page:  
   `gpthemes-chromium-mv3-vX.Y.Z.zip`

7. Visit [ChatGPT](https://chatgpt.com) and **refresh the page** to apply the changes.
