### PR TITLE
Fix hide `Claim offer` chip when `Hide upgrade chips` toggle is enabled

### DIFF
--- a/src/js/app/config/selectors.js
+++ b/src/js/app/config/selectors.js
@@ -125,7 +125,7 @@ export const SELECTORS = {
 		UPGRADE: {
 			TOGGLE_ID: `${PFX}-hide-upgrade-chip`,
 			SELECTOR:
-				'.h-header-height.top-0 button.button-glimmer-cta,.__menu-item[data-testid="accounts-profile-button"] button[data-trailing-button]',
+				'[data-testid="thread-header-right-actions"] button.button-glimmer-cta,.__menu-item[data-testid="accounts-profile-button"] ~ div > button.h-8.w-full.bg-token-bg-primary',
 		},
 	},
 }

--- a/src/sass/customs/_custom--hides.scss
+++ b/src/sass/customs/_custom--hides.scss
@@ -64,8 +64,8 @@ html[data-gpth-hide-footer] {
 /* "Upgrade for free" chip button in header and "Claim offer" button in sidebar */
 html[data-gpth-hide-upgrade-chip] {
 
-    .h-header-height.top-0 button.button-glimmer-cta,
-    .__menu-item[data-testid="accounts-profile-button"] button[data-trailing-button] {
+    [data-testid="thread-header-right-actions"] button.button-glimmer-cta,
+    .__menu-item[data-testid="accounts-profile-button"]~div>button.h-8.w-full.bg-token-bg-primary {
         display: none !important;
     }
 }


### PR DESCRIPTION
Fixes an issue where the "Claim offer" sidebar chip remained visible even when the "Hide upgrade chips" toggle was turned on

---

## Extension Testing Instructions

1. Download the build artifact:  
   `GPThemes-debug-PR#xyz-xyzxyz`

2. Unzip the downloaded artifact to access the files inside.

3. Open the Chrome Extensions page:  
   `chrome://extensions/`

4. Toggle **Developer mode** ON (top-right corner).

5. ⚠️ Before proceeding: If you have GPThemes already installed, disable it first to avoid conflicts.

6. Drag and drop the following file from the extracted folder onto the Extensions page:  
   `gpthemes-chromium-mv3-vX.Y.Z.zip`

7. Visit [ChatGPT](https://chatgpt.com) and **refresh the page** to apply the changes.
